### PR TITLE
fix: force English entity_id slugs regardless of user language

### DIFF
--- a/custom_components/indygo_pool/binary_sensor.py
+++ b/custom_components/indygo_pool/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import IndygoPoolDataUpdateCoordinator
@@ -33,12 +34,14 @@ BINARY_SENSOR_TYPES: tuple[IndygoBinarySensorEntityDescription, ...] = (
     IndygoBinarySensorEntityDescription(
         key="isOnline",
         translation_key="is_online",
+        name="Online",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="shutterEntry",
         translation_key="shutter",
+        name="Shutter",
         device_class=BinarySensorDeviceClass.WINDOW,
         sub_path="ipxData.deviceState",
         is_inverted=True,
@@ -46,6 +49,7 @@ BINARY_SENSOR_TYPES: tuple[IndygoBinarySensorEntityDescription, ...] = (
     IndygoBinarySensorEntityDescription(
         key="flowEntry",
         translation_key="flow",
+        name="Flow",
         device_class=BinarySensorDeviceClass.PROBLEM,
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -53,48 +57,56 @@ BINARY_SENSOR_TYPES: tuple[IndygoBinarySensorEntityDescription, ...] = (
     IndygoBinarySensorEntityDescription(
         key="cmdEntry",
         translation_key="cmd_entry",
+        name="Command",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="canPhEntry",
         translation_key="can_ph_entry",
+        name="pH entry",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="boostEnabled",
         translation_key="boost_enabled",
+        name="Boost",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="testProd",
         translation_key="test_prod",
+        name="Test production",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="pHInjection",
         translation_key="ph_injection",
+        name="pH injection",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="cellPolaruty",
         translation_key="cell_polarity",
+        name="Cell polarity",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="prodStatus",
         translation_key="production_status",
+        name="Production status",
         sub_path="ipxData.deviceState",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoBinarySensorEntityDescription(
         key="0",
         translation_key="filtration",
+        name="Filtration",
         device_class=BinarySensorDeviceClass.RUNNING,
         is_pool_status=True,
     ),
@@ -195,6 +207,10 @@ class IndygoPoolBinarySensor(IndygoPoolEntity, BinarySensorEntity):
             if module_id
             else f"{self._pool_unique_id}_{description.key}"
         )
+
+        # Force English entity_id
+        suffix = slugify(description.translation_key)
+        self.entity_id = f"binary_sensor.{self.device_name_slug}_{suffix}"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/indygo_pool/entity.py
+++ b/custom_components/indygo_pool/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .const import DOMAIN, NAME, VERSION
 from .coordinator import IndygoPoolDataUpdateCoordinator
@@ -47,3 +48,10 @@ class IndygoPoolEntity(CoordinatorEntity[IndygoPoolDataUpdateCoordinator]):
                 model=VERSION,
                 manufacturer=NAME,
             )
+
+    @property
+    def device_name_slug(self) -> str:
+        """Return the device name slug."""
+        if hasattr(self, "_attr_device_info") and self._attr_device_info:
+            return slugify(self._attr_device_info["name"])
+        return slugify(f"{NAME} {self._pool_unique_id[:8]}")

--- a/custom_components/indygo_pool/select.py
+++ b/custom_components/indygo_pool/select.py
@@ -67,10 +67,14 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
         """Initialize."""
         super().__init__(coordinator, module_id)
         self._module_id = module_id
-        self.translation_key = "filtration_mode"
+        self._attr_name = "Filtration mode"
+        self._attr_translation_key = "filtration_mode"
 
         # Unique ID: PoolID_ModuleID_filtration_mode
         self._attr_unique_id = f"{self._pool_unique_id}_{module_id}_filtration_mode"
+
+        # Force English entity_id
+        self.entity_id = f"select.{self.device_name_slug}_filtration_mode"
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/indygo_pool/sensor.py
+++ b/custom_components/indygo_pool/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import IndygoPoolDataUpdateCoordinator
@@ -30,10 +31,12 @@ SENSOR_TYPES: tuple[IndygoSensorEntityDescription, ...] = (
     IndygoSensorEntityDescription(
         key="filtration_status",
         translation_key="filtration_status",
+        name="Filtration status",
     ),
     IndygoSensorEntityDescription(
         key="temperature",
         translation_key="water_temperature",
+        name="Water temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -41,6 +44,7 @@ SENSOR_TYPES: tuple[IndygoSensorEntityDescription, ...] = (
     IndygoSensorEntityDescription(
         key="totalElectrolyseDuration",
         translation_key="electrolyzer_duration",
+        name="Electrolyzer duration",
         native_unit_of_measurement="h",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
@@ -48,26 +52,31 @@ SENSOR_TYPES: tuple[IndygoSensorEntityDescription, ...] = (
     IndygoSensorEntityDescription(
         key="ipx_salt",
         translation_key="ipx_salt",
+        name="Salt level",
         native_unit_of_measurement="g/L",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     IndygoSensorEntityDescription(
         key="ph_setpoint",
         translation_key="ph_setpoint",
+        name="pH setpoint",
     ),
     IndygoSensorEntityDescription(
         key="production_setpoint",
         translation_key="production_setpoint",
+        name="Production setpoint",
         native_unit_of_measurement="%",
     ),
     IndygoSensorEntityDescription(
         key="electrolyzer_mode",
         translation_key="electrolyzer_mode",
+        name="Electrolyzer mode",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     IndygoSensorEntityDescription(
         key="ph",
         translation_key="ph",
+        name="pH",
     ),
 )
 
@@ -145,6 +154,11 @@ class IndygoPoolSensor(IndygoPoolEntity, SensorEntity):
             f"{self._pool_unique_id}_{module_id}_{self._sensor_key}"
             if module_id
             else f"{self._pool_unique_id}_{self._sensor_key}"
+        )
+
+        # Force English entity_id
+        self.entity_id = (
+            f"sensor.{self.device_name_slug}_{slugify(description.translation_key)}"
         )
 
     @property

--- a/custom_components/indygo_pool/strings.json
+++ b/custom_components/indygo_pool/strings.json
@@ -21,6 +21,9 @@
     },
     "entity": {
         "sensor": {
+            "filtration_status": {
+                "name": "Filtration status"
+            },
             "water_temperature": {
                 "name": "Water temperature"
             },

--- a/custom_components/indygo_pool/translations/en.json
+++ b/custom_components/indygo_pool/translations/en.json
@@ -21,6 +21,9 @@
     },
     "entity": {
         "sensor": {
+            "filtration_status": {
+                "name": "Filtration status"
+            },
             "water_temperature": {
                 "name": "Water temperature"
             },

--- a/custom_components/indygo_pool/translations/fr.json
+++ b/custom_components/indygo_pool/translations/fr.json
@@ -21,6 +21,9 @@
     },
     "entity": {
         "sensor": {
+            "filtration_status": {
+                "name": "Statut de la filtration"
+            },
             "water_temperature": {
                 "name": "Température de l'eau"
             },


### PR DESCRIPTION
## Description
This PR addresses the issue where Home Assistant was generating  symbols in the user's local language (e.g., French) instead of English.

## Changes Made
- **Forced English Entity IDs**: Explicitly set  in , , and  using slugified English translation keys.
- **Consistent Prefixes**: Restored the  style prefix by using the device name slug.
- **Improved Slugs**: Standardized on clean  suffixes (e.g.,  instead of ).
- **Translations**: Added missing  translation to  and language files.