### PR TITLE
feat: expose filtration schedule and remaining time from Auto mode

### DIFF
--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from datetime import UTC, datetime
 
 from .const import PROGRAM_TYPE_FILTRATION
 from .models import IndygoModuleData, IndygoPoolData, IndygoSensorData
@@ -296,6 +297,92 @@ class IndygoParser:
 
         return pool_data
 
+    @staticmethod
+    def _minutes_to_time(minutes: int) -> str:
+        """Convert minutes since midnight to HH:MM string."""
+        hours = minutes // 60
+        mins = minutes % 60
+        return f"{hours:02d}:{mins:02d}"
+
+    @staticmethod
+    def _parse_remaining_time(time_str: str) -> int | None:
+        """Parse remaining time string 'HH:MM' into total minutes."""
+        try:
+            parts = time_str.split(":")
+            return int(parts[0]) * 60 + int(parts[1])
+        except (ValueError, IndexError):
+            return None
+
+    @staticmethod
+    def _parse_dialog_timestamp(raw: str | None) -> datetime | None:
+        """Parse dialogTimeStamp (ISO 8601) into a timezone-aware datetime."""
+        if not raw:
+            return None
+        try:
+            dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return None
+
+    def _build_schedule_attributes(
+        self,
+        filt_module: IndygoModuleData,
+        temp_ref: int | None,
+        dialog_ts: datetime | None,
+    ) -> dict:
+        """Build filtration schedule attributes from temperatureSchedules and tempRef.
+
+        Returns a dict of extra attributes to merge into the filtration pool_status.
+        """
+        if temp_ref is None or not filt_module.filtration_program:
+            return {}
+
+        schedules = filt_module.filtration_program.get("temperatureSchedules", [])
+        if not schedules:
+            return {}
+
+        thresholds = schedules[0].get("thresholds", [])
+        if not isinstance(thresholds, list) or temp_ref >= len(thresholds):
+            return {}
+
+        windows = thresholds[temp_ref]
+        if not windows:
+            return {}
+
+        first = windows[0]
+        start_min = first.get("start")
+        end_min = first.get("end")
+        if start_min is None or end_min is None:
+            return {}
+
+        # Build datetime values using dialogTimeStamp date
+        schedule_start = self._minutes_to_time(start_min)
+        schedule_end = self._minutes_to_time(end_min)
+        if dialog_ts:
+            base_date = dialog_ts.replace(hour=0, minute=0, second=0, microsecond=0)
+            schedule_start = base_date.replace(
+                hour=start_min // 60, minute=start_min % 60
+            ).isoformat()
+            schedule_end = base_date.replace(
+                hour=min(end_min // 60, 23), minute=end_min % 60
+            ).isoformat()
+
+        return {
+            "schedule_start": schedule_start,
+            "schedule_end": schedule_end,
+            "schedule_duration_minutes": sum(
+                w.get("end", 0) - w.get("start", 0) for w in windows
+            ),
+            "schedule_windows": [
+                {
+                    "start": self._minutes_to_time(w["start"]),
+                    "end": self._minutes_to_time(w["end"]),
+                }
+                for w in windows
+                if "start" in w and "end" in w
+            ],
+        }
+
     def _parse_pool_status_list(
         self, json_data: dict, pool_data: IndygoPoolData
     ) -> None:
@@ -318,15 +405,42 @@ class IndygoParser:
 
             # Index 0 is Filtration
             if idx == 0:
+                temp_ref = item.get("tempRef")
+                remaining_time = item.get("time")
+
+                extra_attributes = {
+                    "info": item.get("info"),
+                    "time": remaining_time,
+                    "tempRef": temp_ref,
+                }
+
+                # Merge schedule attributes into filtration status
+                if filt_module:
+                    dialog_ts = self._parse_dialog_timestamp(
+                        json_data.get("dialogTimeStamp")
+                    )
+                    extra_attributes.update(
+                        self._build_schedule_attributes(
+                            filt_module, temp_ref, dialog_ts
+                        )
+                    )
+
                 target_status["0"] = IndygoSensorData(
                     key="filtration_status",
                     value=val,
-                    extra_attributes={
-                        "info": item.get("info"),
-                        "time": item.get("time"),
-                        "tempRef": item.get("tempRef"),
-                    },
+                    extra_attributes=extra_attributes,
                 )
+
+                # Remaining filtration time in minutes
+                if remaining_time and filt_module:
+                    remaining_minutes = self._parse_remaining_time(remaining_time)
+                    if remaining_minutes is not None:
+                        filt_module.sensors["filtration_remaining_time"] = (
+                            IndygoSensorData(
+                                key="filtration_remaining_time",
+                                value=remaining_minutes,
+                            )
+                        )
 
     def _parse_root_sensors(self, json_data: dict, pool_data: IndygoPoolData) -> None:
         """Parse root level sensors."""

--- a/custom_components/indygo_pool/sensor.py
+++ b/custom_components/indygo_pool/sensor.py
@@ -74,6 +74,12 @@ SENSOR_TYPES: tuple[IndygoSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),
+    IndygoSensorEntityDescription(
+        key="filtration_remaining_time",
+        translation_key="filtration_remaining_time",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 )
 
 

--- a/custom_components/indygo_pool/translations/en.json
+++ b/custom_components/indygo_pool/translations/en.json
@@ -44,6 +44,9 @@
             },
             "ph": {
                 "name": "pH"
+            },
+            "filtration_remaining_time": {
+                "name": "Filtration remaining time"
             }
         },
         "binary_sensor": {

--- a/custom_components/indygo_pool/translations/fr.json
+++ b/custom_components/indygo_pool/translations/fr.json
@@ -44,6 +44,9 @@
             },
             "ph": {
                 "name": "pH"
+            },
+            "filtration_remaining_time": {
+                "name": "Temps restant filtration"
             }
         },
         "binary_sensor": {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -270,6 +270,345 @@ class TestIndygoParser:
         progs = parser.parse_programs_from_html(html)
         assert progs["MOD1"] == [{"id": 1}]
 
+    def test_parse_filtration_schedule_as_attributes(self):
+        """Test schedule is exposed as attributes on the filtration binary sensor."""
+        parser = IndygoParser()
+        json_data = {
+            "dialogTimeStamp": "2026-03-28T16:28:54Z",
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {
+                                    "thresholds": [
+                                        [{"start": 300, "end": 360}],
+                                        [{"start": 720, "end": 900}],
+                                        [{"start": 660, "end": 960}],
+                                    ]
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "time": "01:30", "tempRef": 2}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        mod = pool_data.modules["MOD1"]
+
+        # Schedule should be in pool_status["0"] extra_attributes
+        attrs = mod.pool_status["0"].extra_attributes
+        assert attrs["schedule_start"] == "2026-03-28T11:00:00+00:00"
+        assert attrs["schedule_end"] == "2026-03-28T16:00:00+00:00"
+        expected_duration = 300
+        assert attrs["schedule_duration_minutes"] == expected_duration
+        assert len(attrs["schedule_windows"]) == 1
+        assert attrs["schedule_windows"][0] == {"start": "11:00", "end": "16:00"}
+
+        # Should NOT be separate sensors
+        assert "filtration_schedule_start" not in mod.sensors
+        assert "filtration_schedule_end" not in mod.sensors
+
+    def test_parse_filtration_schedule_multiple_windows(self):
+        """Test schedule with multiple filtration windows."""
+        parser = IndygoParser()
+        json_data = {
+            "dialogTimeStamp": "2026-03-28T10:00:00Z",
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {
+                                    "thresholds": [
+                                        [
+                                            {"start": 300, "end": 360},
+                                            {"start": 1320, "end": 1380},
+                                        ],
+                                    ]
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "time": "00:45", "tempRef": 0}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+
+        assert attrs["schedule_start"] == "2026-03-28T05:00:00+00:00"
+        assert attrs["schedule_end"] == "2026-03-28T06:00:00+00:00"
+        expected_window_count = 2
+        assert len(attrs["schedule_windows"]) == expected_window_count
+        assert attrs["schedule_windows"][1] == {"start": "22:00", "end": "23:00"}
+        expected_duration = 120
+        assert attrs["schedule_duration_minutes"] == expected_duration
+
+    def test_parse_filtration_schedule_no_dialog_timestamp(self):
+        """Test schedule falls back to HH:MM when dialogTimeStamp is missing."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {"thresholds": [[{"start": 660, "end": 960}]]}
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "tempRef": 0}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert attrs["schedule_start"] == "11:00"
+        assert attrs["schedule_end"] == "16:00"
+
+    def test_parse_filtration_schedule_missing_data(self):
+        """Test schedule parsing with missing data doesn't crash."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "tempRef": 2}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert "schedule_start" not in attrs
+
+    def test_parse_filtration_schedule_temp_ref_out_of_bounds(self):
+        """Test schedule when tempRef exceeds thresholds length."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {"thresholds": [[{"start": 660, "end": 960}]]}
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "tempRef": 99}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert "schedule_start" not in attrs
+
+    def test_parse_filtration_schedule_empty_windows(self):
+        """Test schedule when threshold entry is an empty list."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [{"thresholds": [[]]}],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "tempRef": 0}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert "schedule_start" not in attrs
+
+    def test_parse_filtration_schedule_window_missing_fields(self):
+        """Test schedule when first window is missing start or end."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {"thresholds": [[{"start": 660}]]}
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "tempRef": 0}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert "schedule_start" not in attrs
+
+    def test_parse_filtration_schedule_no_temp_ref(self):
+        """Test schedule parsing when tempRef is missing."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                            "temperatureSchedules": [
+                                {"thresholds": [[{"start": 660, "end": 960}]]}
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        attrs = pool_data.modules["MOD1"].pool_status["0"].extra_attributes
+        assert "schedule_start" not in attrs
+
+    def test_parse_remaining_time(self):
+        """Test remaining filtration time parsing."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 1, "time": "01:30", "tempRef": 2}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        mod = pool_data.modules["MOD1"]
+        assert "filtration_remaining_time" in mod.sensors
+        expected_minutes = 90
+        assert mod.sensors["filtration_remaining_time"].value == expected_minutes
+
+    def test_parse_remaining_time_zero(self):
+        """Test remaining time when filtration is done."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "pool": [{"index": 0, "value": 0, "time": "00:00", "tempRef": 2}],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        mod = pool_data.modules["MOD1"]
+        assert mod.sensors["filtration_remaining_time"].value == 0
+
+    def test_minutes_to_time(self):
+        """Test minutes to time conversion."""
+        assert IndygoParser._minutes_to_time(0) == "00:00"
+        assert IndygoParser._minutes_to_time(60) == "01:00"
+        assert IndygoParser._minutes_to_time(660) == "11:00"
+        assert IndygoParser._minutes_to_time(1440) == "24:00"
+        assert IndygoParser._minutes_to_time(90) == "01:30"
+
+    def test_parse_remaining_time_helper(self):
+        """Test _parse_remaining_time helper."""
+        expected_90 = 90
+        expected_165 = 165
+        assert IndygoParser._parse_remaining_time("01:30") == expected_90
+        assert IndygoParser._parse_remaining_time("00:00") == 0
+        assert IndygoParser._parse_remaining_time("02:45") == expected_165
+        assert IndygoParser._parse_remaining_time("invalid") is None
+        assert IndygoParser._parse_remaining_time("") is None
+
+    def test_parse_dialog_timestamp(self):
+        """Test _parse_dialog_timestamp helper."""
+        dt = IndygoParser._parse_dialog_timestamp("2026-03-28T16:28:54Z")
+        assert dt is not None
+        expected_year = 2026
+        expected_month = 3
+        expected_day = 28
+        assert dt.year == expected_year
+        assert dt.month == expected_month
+        assert dt.day == expected_day
+        assert dt.tzinfo is not None
+
+        assert IndygoParser._parse_dialog_timestamp(None) is None
+        assert IndygoParser._parse_dialog_timestamp("not-a-date") is None
+
     def test_parse_data_edge_cases(self):
         """Test full data parsing edge cases."""
         parser = IndygoParser()


### PR DESCRIPTION
Parse temperatureSchedules from the filtration program and cross-reference with tempRef from pool status to determine the active filtration window.

- Schedule start/end and windows exposed as attributes on the filtration binary sensor (uses dialogTimeStamp for date, falls back to HH:MM)
- Remaining filtration time exposed as a dedicated sensor in minutes