### PR TITLE
refactor: simplify codebase with shared helpers, cached state, and stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close stale issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          days-before-issue-stale: 60
+          days-before-pr-stale: 60
+          days-before-close: 7
+          remove-stale-when-updated: true
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 7 days if no
+            further activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been stale for 7 days with no
+            activity.
+          close-pr-message: >
+            This pull request was closed because it has been stale for 7 days
+            with no activity.
+          exempt-issue-labels: no-stale,pinned,security,help-wanted
+          exempt-pr-labels: no-stale,pinned,security
+          exempt-pr-authors: renovate[bot]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -36,6 +36,7 @@ class IndygoPoolApiClient:
             "Chrome/120.0.0.0 Safari/537.36"
         )
     }
+    JSON_HEADERS = {"Content-Type": "application/json"}
 
     def __init__(
         self,
@@ -144,16 +145,13 @@ class IndygoPoolApiClient:
     async def async_login(self) -> None:
         """Login to the API."""
         try:
-            # Login payload
             data = {
                 "email": self._email,
                 "password": self._password,
             }
 
-            # Perform login
             await self._request("GET", "https://myindygo.com/login", retry_auth=False)
 
-            # Then POST credentials
             async with self._session.post(
                 "https://myindygo.com/login",
                 data=data,
@@ -182,35 +180,35 @@ class IndygoPoolApiClient:
 
     async def async_refresh_scraped_data(self) -> None:
         """Fetch and parse the pool devices page to get fresh scraped data."""
-        # Note: We run this every update because some data (IPX sensors) is only
-        # available on the devices page HTML/JS, not in the status JSON API.
-
         url = f"https://myindygo.com/pools/{self._pool_id}/devices"
         text = await self._request("GET", url, retry_auth=True)
-        # Type check helper since _request returns Union
         if not isinstance(text, str):
-            # Should not happen if return_json=False
             text = str(text)
 
-        # Parse Pool IDs and metadata
-        pool_address, device_short_id, relay_id, pool_metadata = (
-            self._parser.parse_pool_ids(text, self._pool_id)
+        # Static IDs (pool_address, device_short_id, relay_id) are tied to
+        # hardware and don't change between polls — parse them only once.
+        ids_missing = (
+            not self._pool_address or not self._device_short_id or not self._relay_id
         )
-        self._ipx_module_metadata = self._parser.parse_ipx_module(text)
-
-        # Parse Programs (from embedded JS)
-        self._scraped_programs = self._parser.parse_programs_from_html(text)
-
-        if not pool_address or not device_short_id or not relay_id:
-            LOGGER.error("HTML (truncated): %s", text[:1000])
-            raise IndygoPoolApiClientError(
-                "Could not determine Pool Address, Device Short ID, or Relay ID."
+        if ids_missing:
+            pool_address, device_short_id, relay_id, pool_metadata = (
+                self._parser.parse_pool_ids(text, self._pool_id)
             )
 
-        self._pool_address = pool_address
-        self._device_short_id = device_short_id
-        self._relay_id = relay_id
-        self._pool_metadata = pool_metadata
+            if not pool_address or not device_short_id or not relay_id:
+                LOGGER.error("HTML (truncated): %s", text[:1000])
+                raise IndygoPoolApiClientError(
+                    "Could not determine Pool Address, Device Short ID, or Relay ID."
+                )
+
+            self._pool_address = pool_address
+            self._device_short_id = device_short_id
+            self._relay_id = relay_id
+            self._pool_metadata = pool_metadata
+
+        # Dynamic data — always refresh
+        self._ipx_module_metadata = self._parser.parse_ipx_module(text)
+        self._scraped_programs = self._parser.parse_programs_from_html(text)
 
         LOGGER.debug(
             "Refreshed scraped data: gateway_serial=%s, device_short_id=%s, "
@@ -280,10 +278,8 @@ class IndygoPoolApiClient:
         We MUST send back the FULL program object, otherwise we risk corrupting
         the device configuration (erasing timers, etc.).
         """
-        # 1. Deep copy to avoid mutating the source
         program_copy = copy.deepcopy(full_program_data)
 
-        # 2. Update the mode
         # Mode: 0=OFF, 1=ON, 2=AUTO
         if "programCharacteristics" in program_copy:
             program_copy["programCharacteristics"]["mode"] = mode
@@ -292,10 +288,7 @@ class IndygoPoolApiClient:
                 "Invalid program data: missing programCharacteristics"
             )
 
-        # 3. Set dataChanged flag to trigger activation
         program_copy["dataChanged"] = True
-
-        # 4. Fetch all programs and module name to send a complete set
         module_programs = []
         module_name = ""
         if self._data and module_id in self._data.modules:
@@ -308,11 +301,12 @@ class IndygoPoolApiClient:
         # and set dataChanged=True on ALL programs
         updated_programs = []
         program_id = program_copy.get("id")
+        program_found = False
         for prog in module_programs:
             if prog.get("id") == program_id:
                 updated_programs.append(program_copy)
+                program_found = True
             else:
-                # Deep copy other programs and set dataChanged=True on them too
                 prog_copy = copy.deepcopy(prog)
                 prog_copy["dataChanged"] = True
 
@@ -321,7 +315,6 @@ class IndygoPoolApiClient:
                     "programType"
                 )
                 if prog_type != PROGRAM_TYPE_FILTRATION:
-                    # Set mode to None for non-filtration programs
                     if (
                         "programCharacteristics" in prog_copy
                         and "mode" in prog_copy["programCharacteristics"]
@@ -330,7 +323,7 @@ class IndygoPoolApiClient:
 
                 updated_programs.append(prog_copy)
 
-        if not any(p.get("id") == program_id for p in updated_programs):
+        if not program_found:
             updated_programs.append(program_copy)
 
         # 5. Construct payload with ALL programs
@@ -350,7 +343,7 @@ class IndygoPoolApiClient:
         )
 
         try:
-            headers = {"Content-Type": "application/json"}
+            headers = self.JSON_HEADERS
 
             module_payload = {
                 "module": {
@@ -472,7 +465,7 @@ class IndygoPoolApiClient:
             LOGGER.warning("Missing relay_id, skipping remote sync")
             return
 
-        headers = {"Content-Type": "application/json"}
+        headers = self.JSON_HEADERS
         LOGGER.debug(
             "Applying remote changes for module %s (relay: %s)", module_id, relay_id
         )
@@ -568,7 +561,7 @@ class IndygoPoolApiClient:
         await self._request(
             "POST",
             "https://myindygo.com/remote/module/control",
-            headers={"Content-Type": "application/json"},
+            headers=self.JSON_HEADERS,
             data=json.dumps(payload),
             return_json=True,
             retry_auth=True,
@@ -597,7 +590,7 @@ class IndygoPoolApiClient:
             await self._request(
                 "POST",
                 url,
-                headers={"Content-Type": "application/json"},
+                headers=self.JSON_HEADERS,
                 data=json.dumps(payload),
                 return_json=True,
                 retry_auth=True,

--- a/custom_components/indygo_pool/binary_sensor.py
+++ b/custom_components/indygo_pool/binary_sensor.py
@@ -185,21 +185,19 @@ class IndygoPoolBinarySensor(IndygoPoolEntity, BinarySensorEntity):
         """Initialize."""
         super().__init__(coordinator, module_id)
         self.entity_description = description
-        self._module_id = module_id
 
         if description.key == "isOnline" and module_name:
             self._attr_translation_placeholders = {"module": module_name}
 
-        # Unique ID: PoolID_ModuleID_Key
-        self._attr_unique_id = (
-            f"{self._pool_unique_id}_{module_id}_{description.key}"
-            if module_id
-            else f"{self._pool_unique_id}_{description.key}"
-        )
-
-        # Force English entity_id
+        self._attr_unique_id = self._build_unique_id(description.key)
         suffix = slugify(description.translation_key)
         self.entity_id = f"binary_sensor.{self.device_name_slug}_{suffix}"
+
+    def _get_pool_status(self) -> dict:
+        """Resolve the correct pool_status dict (module-level or root)."""
+        if self._module_id and self._module_id in self.coordinator.data.modules:
+            return self.coordinator.data.modules[self._module_id].pool_status
+        return self.coordinator.data.pool_status
 
     @property
     def is_on(self) -> bool | None:
@@ -207,15 +205,9 @@ class IndygoPoolBinarySensor(IndygoPoolEntity, BinarySensorEntity):
         desc = self.entity_description
 
         if desc.is_pool_status:
-            target_status = self.coordinator.data.pool_status
-            if self._module_id and self._module_id in self.coordinator.data.modules:
-                target_status = self.coordinator.data.modules[
-                    self._module_id
-                ].pool_status
-
+            target_status = self._get_pool_status()
             if desc.key in target_status:
-                data = target_status[desc.key]
-                val = data.value
+                val = target_status[desc.key].value
                 if val is not None:
                     try:
                         return float(val) == 1.0
@@ -250,12 +242,7 @@ class IndygoPoolBinarySensor(IndygoPoolEntity, BinarySensorEntity):
         """Return the state attributes."""
         desc = self.entity_description
         if desc.is_pool_status:
-            target_status = self.coordinator.data.pool_status
-            if self._module_id and self._module_id in self.coordinator.data.modules:
-                target_status = self.coordinator.data.modules[
-                    self._module_id
-                ].pool_status
-
+            target_status = self._get_pool_status()
             if desc.key in target_status:
                 return target_status[desc.key].extra_attributes
         return None

--- a/custom_components/indygo_pool/entity.py
+++ b/custom_components/indygo_pool/entity.py
@@ -23,6 +23,7 @@ class IndygoPoolEntity(CoordinatorEntity[IndygoPoolDataUpdateCoordinator]):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
+        self._module_id = module_id
 
         if coordinator.data and coordinator.data.pool_id:
             pool_id = coordinator.data.pool_id
@@ -49,9 +50,15 @@ class IndygoPoolEntity(CoordinatorEntity[IndygoPoolDataUpdateCoordinator]):
                 manufacturer=NAME,
             )
 
+        self._device_name_slug = slugify(self._attr_device_info["name"])
+
     @property
     def device_name_slug(self) -> str:
         """Return the device name slug."""
-        if self._attr_device_info:
-            return slugify(self._attr_device_info["name"])
-        return slugify(f"{NAME} {self._pool_unique_id[:8]}")
+        return self._device_name_slug
+
+    def _build_unique_id(self, key: str) -> str:
+        """Build a unique ID from pool ID, optional module ID, and key."""
+        if self._module_id:
+            return f"{self._pool_unique_id}_{self._module_id}_{key}"
+        return f"{self._pool_unique_id}_{key}"

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 from datetime import UTC, datetime
+from typing import Any
 
 from .const import PROGRAM_TYPE_FILTRATION
 from .models import IndygoModuleData, IndygoPoolData, IndygoSensorData
@@ -14,6 +15,29 @@ _LOGGER = logging.getLogger(__name__)
 
 
 IPX_PH_SENSOR_TYPE = 6
+
+
+def _get_nested(obj: dict | list | None, *keys: str) -> Any:
+    """Safely traverse nested dicts/lists by key or index."""
+    for k in keys:
+        if not isinstance(obj, (dict, list)):
+            return None
+        if isinstance(obj, list):
+            try:
+                obj = obj[int(k)]
+            except (IndexError, ValueError):
+                return None
+        else:
+            obj = obj.get(k)
+    return obj
+
+
+def _js_var_regex(var_name: str, delimiter: str = r"[{\[]") -> re.Pattern:
+    """Build a compiled regex to match a JS variable assignment."""
+    return re.compile(
+        rf"(?:var|let|const|window\.)\s*{var_name}\s*=\s*({delimiter})",
+        re.IGNORECASE,
+    )
 
 
 class IndygoParser:
@@ -131,11 +155,7 @@ class IndygoParser:
         Returns:
             Tuple of (pool_address, device_short_id, relay_id, pool_metadata_dict)
         """
-        # Extract currentPool JSON
-        start_regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*currentPool\s*=\s*([{\[])", re.IGNORECASE
-        )
-        match = start_regex.search(html)
+        match = _js_var_regex("currentPool").search(html)
 
         json_str = None
         pool_metadata = {}
@@ -151,11 +171,7 @@ class IndygoParser:
                 _LOGGER.error("Failed to decode currentPool JSON: %s", exc)
                 return None, None, None, {}
         else:
-            # Fallback to modulesInPool
-            modules_regex = re.compile(
-                r"(?:var|let|const|window\.)?\s*modulesInPool\s*=\s*(\[)", re.IGNORECASE
-            )
-            match = modules_regex.search(html)
+            match = _js_var_regex("modulesInPool", r"\[").search(html)
             if match:
                 start_index = match.start(1)
                 json_str = self.extract_json_object(html, start_index)
@@ -189,12 +205,7 @@ class IndygoParser:
         """Parse HTML to find ipxModule data (embedded JS)."""
         ipx_metadata = {}
 
-        # 1. Search for poolTechModulesIpx (contains outputs for electrolyzer settings)
-        pooltech_regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*poolTechModulesIpx\s*=\s*(\[)",
-            re.IGNORECASE,
-        )
-        match = pooltech_regex.search(html)
+        match = _js_var_regex("poolTechModulesIpx", r"\[").search(html)
         if match and (json_str := self.extract_json_object(html, match.start(1))):
             try:
                 modules_list = json.loads(json_str)
@@ -205,11 +216,7 @@ class IndygoParser:
             except json.JSONDecodeError as exc:
                 _LOGGER.error("Failed to decode poolTechModulesIpx JSON: %s", exc)
 
-        # 2. Search for ipxModule (legacy single object)
-        ipx_start_regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*ipxModule\s*=\s*(\{)", re.IGNORECASE
-        )
-        match = ipx_start_regex.search(html)
+        match = _js_var_regex("ipxModule", r"\{").search(html)
         if match and (json_str := self.extract_json_object(html, match.start(1))):
             try:
                 ipx_metadata = json.loads(json_str)
@@ -217,11 +224,7 @@ class IndygoParser:
             except json.JSONDecodeError as exc:
                 _LOGGER.error("Failed to decode ipxModule JSON: %s", exc)
 
-        # 3. Fallback to modulesInPool (new general module list but misses outputs)
-        modules_regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*modulesInPool\s*=\s*(\[)", re.IGNORECASE
-        )
-        match = modules_regex.search(html)
+        match = _js_var_regex("modulesInPool", r"\[").search(html)
         if match and (json_str := self.extract_json_object(html, match.start(1))):
             try:
                 modules_list = json.loads(json_str)
@@ -238,11 +241,7 @@ class IndygoParser:
         """Parse programs from embedded HTML JSON."""
         programs_map: dict[str, list[dict]] = {}
 
-        # Regex for 'const poolCommand'
-        regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*poolCommand\s*=\s*(\{)", re.IGNORECASE
-        )
-        match = regex.search(html)
+        match = _js_var_regex("poolCommand", r"\{").search(html)
         if match and (json_str := self.extract_json_object(html, match.start(1))):
             try:
                 data = json.loads(json_str)
@@ -255,11 +254,7 @@ class IndygoParser:
                 _LOGGER.error("Failed to decode poolCommand JSON: %s", exc)
             return programs_map
 
-        # Fallback to modulesInPool
-        modules_regex = re.compile(
-            r"(?:var|let|const|window\.)?\s*modulesInPool\s*=\s*(\[)", re.IGNORECASE
-        )
-        match = modules_regex.search(html)
+        match = _js_var_regex("modulesInPool", r"\[").search(html)
         if match and (json_str := self.extract_json_object(html, match.start(1))):
             try:
                 for m in json.loads(json_str):
@@ -270,6 +265,16 @@ class IndygoParser:
             except json.JSONDecodeError as exc:
                 _LOGGER.error("Failed to decode modulesInPool JSON: %s", exc)
         return programs_map
+
+    @staticmethod
+    def _find_filtration_module(
+        pool_data: IndygoPoolData,
+    ) -> IndygoModuleData | None:
+        """Find the module responsible for filtration."""
+        return next(
+            (m for m in pool_data.modules.values() if m.filtration_program),
+            next((m for m in pool_data.modules.values() if m.type == "lr-pc"), None),
+        )
 
     def parse_data(
         self,
@@ -290,10 +295,11 @@ class IndygoParser:
         # 2. Scraped IPX Data
         self._parse_scraped_ipx(json_data, pool_data)
 
-        # 3. Main Pool Data
-        self._parse_root_sensors(json_data, pool_data)
-        self._parse_sensor_state(json_data, pool_data)
-        self._parse_pool_status_list(json_data, pool_data)
+        # 3. Main Pool Data — resolve filtration module once
+        filt_module = self._find_filtration_module(pool_data)
+        self._parse_root_sensors(json_data, pool_data, filt_module)
+        self._parse_sensor_state(json_data, pool_data, filt_module)
+        self._parse_pool_status_list(json_data, pool_data, filt_module)
 
         return pool_data
 
@@ -384,17 +390,14 @@ class IndygoParser:
         }
 
     def _parse_pool_status_list(
-        self, json_data: dict, pool_data: IndygoPoolData
+        self,
+        json_data: dict,
+        pool_data: IndygoPoolData,
+        filt_module: IndygoModuleData | None = None,
     ) -> None:
         """Parse 'pool' list which contains status for Filtration, etc."""
         if "pool" not in json_data or not isinstance(json_data["pool"], list):
             return
-
-        # Find Filtration Module to attach sensors
-        filt_module = next(
-            (m for m in pool_data.modules.values() if m.filtration_program),
-            next((m for m in pool_data.modules.values() if m.type == "lr-pc"), None),
-        )
         target_status = (
             filt_module.pool_status if filt_module else pool_data.pool_status
         )
@@ -442,7 +445,12 @@ class IndygoParser:
                             )
                         )
 
-    def _parse_root_sensors(self, json_data: dict, pool_data: IndygoPoolData) -> None:
+    def _parse_root_sensors(
+        self,
+        json_data: dict,
+        pool_data: IndygoPoolData,
+        filt_module: IndygoModuleData | None = None,
+    ) -> None:
         """Parse root level sensors."""
         root_sensors_map = {
             "temperature": {
@@ -450,11 +458,6 @@ class IndygoParser:
             },
         }
 
-        # Find Filtration Module (Temperature is from LR-PC)
-        filt_module = next(
-            (m for m in pool_data.modules.values() if m.filtration_program),
-            next((m for m in pool_data.modules.values() if m.type == "lr-pc"), None),
-        )
         target_sensors = filt_module.sensors if filt_module else pool_data.sensors
 
         for key, config in root_sensors_map.items():
@@ -472,18 +475,18 @@ class IndygoParser:
                     extra_attributes=extra_attributes,
                 )
 
-    def _parse_sensor_state(self, json_data: dict, pool_data: IndygoPoolData) -> None:
+    def _parse_sensor_state(
+        self,
+        json_data: dict,
+        pool_data: IndygoPoolData,
+        filt_module: IndygoModuleData | None = None,
+    ) -> None:
         """Parse sensorState (legacy/generic list)."""
         if "sensorState" not in json_data or not isinstance(
             json_data["sensorState"], list
         ):
             return
 
-        # Find Filtration Module (Temperature is from LR-PC)
-        filt_module = next(
-            (m for m in pool_data.modules.values() if m.filtration_program),
-            next((m for m in pool_data.modules.values() if m.type == "lr-pc"), None),
-        )
         target_sensors = filt_module.sensors if filt_module else pool_data.sensors
 
         for sensor_item in json_data["sensorState"]:
@@ -565,42 +568,24 @@ class IndygoParser:
         # Fallback to root sensors if no module found
         target_sensors = ipx_module.sensors if ipx_module else pool_data.sensors
 
-        # Helper to safely get nested
-        def get_nested(obj, *keys):
-            for k in keys:
-                if not isinstance(obj, (dict, list)):
-                    return None
-                if isinstance(obj, list):
-                    try:
-                        obj = obj[int(k)]
-                    except (IndexError, ValueError):
-                        return None
-                else:
-                    obj = obj.get(k)
-            return obj
-
-        # Salt
-        salt = get_nested(outputs, 1, "ipxData", "saltValue")
+        salt = _get_nested(outputs, 1, "ipxData", "saltValue")
         if salt is not None:
             target_sensors["ipx_salt"] = IndygoSensorData(key="ipx_salt", value=salt)
 
-        # pH Setpoint
-        ph_set = get_nested(outputs, 0, "ipxData", "pHSetpoint")
+        ph_set = _get_nested(outputs, 0, "ipxData", "pHSetpoint")
         if ph_set is not None:
             target_sensors["ph_setpoint"] = IndygoSensorData(
                 key="ph_setpoint", value=ph_set
             )
 
-        # Production Setpoint
-        prod_set = get_nested(outputs, 1, "ipxData", "percentageSetpoint")
+        prod_set = _get_nested(outputs, 1, "ipxData", "percentageSetpoint")
         if prod_set is not None:
             target_sensors["production_setpoint"] = IndygoSensorData(
                 key="production_setpoint",
                 value=prod_set,
             )
 
-        # Electrolyzer Mode
-        elec_mode = get_nested(outputs, 1, "ipxData", "electrolyzerMode")
+        elec_mode = _get_nested(outputs, 1, "ipxData", "electrolyzerMode")
         if elec_mode is not None:
             target_sensors["electrolyzer_mode"] = IndygoSensorData(
                 key="electrolyzer_mode",

--- a/custom_components/indygo_pool/select.py
+++ b/custom_components/indygo_pool/select.py
@@ -66,13 +66,8 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator, module_id)
-        self._module_id = module_id
         self._attr_translation_key = "filtration_mode"
-
-        # Unique ID: PoolID_ModuleID_filtration_mode
-        self._attr_unique_id = f"{self._pool_unique_id}_{module_id}_filtration_mode"
-
-        # Force English entity_id
+        self._attr_unique_id = self._build_unique_id("filtration_mode")
         self.entity_id = f"select.{self.device_name_slug}_filtration_mode"
 
     @property

--- a/custom_components/indygo_pool/sensor.py
+++ b/custom_components/indygo_pool/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.util import slugify
 from .const import DOMAIN
 from .coordinator import IndygoPoolDataUpdateCoordinator
 from .entity import IndygoPoolEntity
+from .models import IndygoSensorData
 
 
 @dataclass
@@ -148,51 +149,31 @@ class IndygoPoolSensor(IndygoPoolEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator, module_id)
         self.entity_description = description
-        self._sensor_key = description.key
-        self._module_id = module_id
-
-        # Unique ID: PoolID_ModuleID_Key
-        self._attr_unique_id = (
-            f"{self._pool_unique_id}_{module_id}_{self._sensor_key}"
-            if module_id
-            else f"{self._pool_unique_id}_{self._sensor_key}"
-        )
-
-        # Force English entity_id
+        self._attr_unique_id = self._build_unique_id(description.key)
         self.entity_id = (
             f"sensor.{self.device_name_slug}_{slugify(description.translation_key)}"
         )
 
-    @property
-    def native_value(self) -> float | str | None:
-        """Return the native value of the sensor."""
+    def _get_sensor_data(self) -> IndygoSensorData | None:
+        """Resolve the sensor data from module or root sensors."""
         data = self.coordinator.data
         if not data:
             return None
-
+        key = self.entity_description.key
         if self._module_id and self._module_id in data.modules:
-            module = data.modules[self._module_id]
-            if self._sensor_key in module.sensors:
-                return module.sensors[self._sensor_key].value
+            sensor = data.modules[self._module_id].sensors.get(key)
+            if sensor:
+                return sensor
+        return data.sensors.get(key)
 
-        if self._sensor_key in data.sensors:
-            return data.sensors[self._sensor_key].value
-
-        return None
+    @property
+    def native_value(self) -> float | str | None:
+        """Return the native value of the sensor."""
+        sensor = self._get_sensor_data()
+        return sensor.value if sensor else None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
-        data = self.coordinator.data
-        if not data:
-            return None
-
-        if self._module_id:
-            if self._module_id in data.modules:
-                module = data.modules[self._module_id]
-                if self._sensor_key in module.sensors:
-                    return module.sensors[self._sensor_key].extra_attributes
-        elif self._sensor_key in data.sensors:
-            return data.sensors[self._sensor_key].extra_attributes
-
-        return None
+        sensor = self._get_sensor_data()
+        return sensor.extra_attributes if sensor else None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,7 @@ from custom_components.indygo_pool.api import (
     IndygoPoolApiClient,
     IndygoPoolApiClientAuthenticationError,
     IndygoPoolApiClientCommunicationError,
+    IndygoPoolApiClientError,
 )
 from custom_components.indygo_pool.models import IndygoPoolData
 
@@ -125,6 +126,8 @@ async def test_set_filtration_mode():
             client._relay_id = TEST_RELAY_ID
             client._pool_address = TEST_POOL_ADDRESS
             client._token = "fake_token"
+            # Populate scraped programs so the loop finds the program
+            client._scraped_programs = {TEST_MODULE_ID: [filt_program]}
 
             await client.async_set_filtration_mode(
                 TEST_MODULE_ID, filt_program, expected_mode
@@ -442,3 +445,77 @@ async def test_api_synchronize_lorawan():
             payload = json.loads(req.kwargs["data"])
             assert payload["moduleId"] == "mod1"
             assert payload["sendProgram"] is True
+
+
+DEVICES_HTML = """
+<script>
+var currentPool = {
+    "id": 12345,
+    "modules": [
+        {"type": "lr-mb-10", "serialNumber": "GW_SERIAL", "name": "Gateway"},
+        {"type": "lr-pc", "serialNumber": "LRPC_SERIAL", "name": "Pump-ABC",
+         "relay": "RELAY_1"}
+    ]
+};
+var poolTechModulesIpx = [{"type": "ipx_v1", "id": 1}];
+var poolCommand = {
+    "programs": [
+        {"module": "mod_1", "programCharacteristics": {"programType": 4, "mode": 2}}
+    ]
+};
+</script>
+"""
+
+
+@pytest.mark.asyncio
+async def test_refresh_scraped_data_caches_static_ids():
+    """Test that static IDs are parsed on first call and cached on subsequent calls."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    devices_url = f"https://myindygo.com/pools/{TEST_POOL_ID}/devices"
+
+    with aioresponses() as m:
+        m.get(devices_url, body=DEVICES_HTML)
+        m.get(devices_url, body=DEVICES_HTML)
+
+        async with aiohttp.ClientSession() as session:
+            client = IndygoPoolApiClient(
+                "test@example.com", "pass", TEST_POOL_ID, session
+            )
+
+            # First call: IDs should be parsed
+            await client.async_refresh_scraped_data()
+            assert client._pool_address == "GW_SERIAL"
+            assert client._device_short_id == "ABC"
+            assert client._relay_id == "RELAY_1"
+
+            # Second call: IDs should be cached, parse_pool_ids not called again
+            with patch.object(client._parser, "parse_pool_ids") as mock_parse:
+                await client.async_refresh_scraped_data()
+                mock_parse.assert_not_called()
+
+            # Dynamic data should still be refreshed
+            assert client._ipx_module_metadata is not None
+            assert client._scraped_programs is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_scraped_data_raises_on_missing_ids():
+    """Test that an error is raised when static IDs cannot be parsed."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    html_no_modules = "<html><body>No data here</body></html>"
+    devices_url = f"https://myindygo.com/pools/{TEST_POOL_ID}/devices"
+
+    with aioresponses() as m:
+        m.get(devices_url, body=html_no_modules)
+
+        async with aiohttp.ClientSession() as session:
+            client = IndygoPoolApiClient(
+                "test@example.com", "pass", TEST_POOL_ID, session
+            )
+
+            with pytest.raises(IndygoPoolApiClientError, match="Could not determine"):
+                await client.async_refresh_scraped_data()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,10 @@
 """Tests for Indygo Parser."""
 
-from custom_components.indygo_pool.parser import IndygoParser
+from custom_components.indygo_pool.parser import (
+    IndygoParser,
+    _get_nested,
+    _js_var_regex,
+)
 
 # Constants for testing
 TEST_POOL_ID = "123"
@@ -628,3 +632,56 @@ class TestIndygoParser:
             {"ipx_module": {"outputs": [{"ipxData": {}}]}}, "POOL1", "ADDR1", "RELAY1"
         )
         assert "ipx_salt" not in data.sensors
+
+
+class TestGetNested:
+    """Tests for the _get_nested helper."""
+
+    def test_traverses_dict(self):
+        """Test basic dict traversal."""
+        assert _get_nested({"a": {"b": 1}}, "a", "b") == 1
+
+    def test_traverses_list_by_index(self):
+        """Test list traversal by numeric key."""
+        expected = 20
+        assert _get_nested([10, 20, 30], "1") == expected
+
+    def test_returns_none_on_non_traversable(self):
+        """Test early return when encountering a non-dict/list value."""
+        assert _get_nested({"a": 42}, "a", "b") is None
+
+    def test_returns_none_on_none_input(self):
+        """Test with None input."""
+        assert _get_nested(None, "a") is None
+
+    def test_returns_none_on_index_error(self):
+        """Test with out-of-range list index."""
+        assert _get_nested([1], "5") is None
+
+    def test_returns_none_on_invalid_index(self):
+        """Test with non-numeric key on a list."""
+        assert _get_nested([1, 2], "abc") is None
+
+
+class TestJsVarRegex:
+    """Tests for the _js_var_regex helper."""
+
+    def test_matches_var(self):
+        """Test matching var declaration."""
+        regex = _js_var_regex("myVar", r"\{")
+        assert regex.search("var myVar = {};") is not None
+
+    def test_matches_const(self):
+        """Test matching const declaration."""
+        regex = _js_var_regex("myVar", r"\[")
+        assert regex.search("const myVar = [];") is not None
+
+    def test_matches_window_dot(self):
+        """Test matching window.property assignment."""
+        regex = _js_var_regex("myVar")
+        assert regex.search("window.myVar = {};") is not None
+
+    def test_no_match(self):
+        """Test no match for unrelated content."""
+        regex = _js_var_regex("myVar")
+        assert regex.search("var otherVar = {};") is None


### PR DESCRIPTION
- Extract _find_filtration_module, _js_var_regex, _get_nested helpers in parser
- Cache static hardware IDs in API client to skip redundant HTML parsing
- Move _module_id, _build_unique_id, device_name_slug caching to base entity
- Extract _get_pool_status and _get_sensor_data helpers in entity platforms
- Add JSON_HEADERS class constant and track program_found flag in API client
- Add tests for new module-level helpers
- Add GitHub Actions workflow for stale issues and PRs management