### PR TITLE
fix: add delayed refresh after filtration mode change

### DIFF
--- a/custom_components/indygo_pool/select.py
+++ b/custom_components/indygo_pool/select.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .const import DOMAIN, LOGGER
 from .coordinator import IndygoPoolDataUpdateCoordinator
 from .entity import IndygoPoolEntity
 from .models import IndygoModuleData
+
+# Delay (seconds) before a follow-up refresh after a mode change.
+# The command travels cloud → gateway → LoRa → device, so the status
+# endpoint may still return the old state right after the API call.
+DELAYED_REFRESH_SECONDS = 10
 
 # Mapping: Mode -> Integer
 MODE_OFF = "Off"
@@ -69,6 +75,7 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
         self._attr_translation_key = "filtration_mode"
         self._attr_unique_id = self._build_unique_id("filtration_mode")
         self.entity_id = f"select.{self.device_name_slug}_filtration_mode"
+        self._cancel_delayed_refresh: CALLBACK_TYPE | None = None
 
     @property
     def current_option(self) -> str | None:
@@ -110,5 +117,25 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
             self._module_id, module.filtration_program, mode_int
         )
 
-        # Trigger refresh
+        # Trigger immediate refresh
+        await self.coordinator.async_request_refresh()
+
+        # Schedule a delayed refresh to capture the device state after
+        # the command has propagated through cloud → gateway → LoRa.
+        self._schedule_delayed_refresh()
+
+    def _schedule_delayed_refresh(self) -> None:
+        """Schedule a coordinator refresh after a delay."""
+        if self._cancel_delayed_refresh:
+            self._cancel_delayed_refresh()
+
+        self._cancel_delayed_refresh = async_call_later(
+            self.hass,
+            DELAYED_REFRESH_SECONDS,
+            self._async_delayed_refresh,
+        )
+
+    async def _async_delayed_refresh(self, _now: object) -> None:
+        """Perform the delayed coordinator refresh."""
+        self._cancel_delayed_refresh = None
         await self.coordinator.async_request_refresh()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,6 @@
 """Tests for the Indygo Pool select entity."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntry
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.indygo_pool.models import IndygoModuleData, IndygoPoolData
 from custom_components.indygo_pool.select import (
+    DELAYED_REFRESH_SECONDS,
     MODE_AUTO,
     MODE_OFF,
     MODE_ON,
@@ -115,15 +116,78 @@ class TestIndygoPoolSelect:
 
         entity = IndygoPoolSelect(mock_coordinator, module_id, "Pump")
 
-        # Select Auto
-        await entity.async_select_option(MODE_AUTO)
+        with patch(
+            "custom_components.indygo_pool.select.async_call_later"
+        ) as mock_call_later:
+            await entity.async_select_option(MODE_AUTO)
 
         # Verify API called with correct args (mode 2 for Auto)
         mock_coordinator.client.async_set_filtration_mode.assert_called_once_with(
             module_id, filtration_program, 2
         )
-        # Verify refresh requested
+        # Verify immediate refresh requested
         mock_coordinator.async_request_refresh.assert_called_once()
+        # Verify delayed refresh scheduled
+        mock_call_later.assert_called_once()
+        args = mock_call_later.call_args
+        assert args[0][1] == DELAYED_REFRESH_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_delayed_refresh_cancels_previous(self, mock_coordinator):
+        """Test that a new mode change cancels the previous delayed refresh."""
+        module_id = "mod1"
+        filtration_program = {"programCharacteristics": {"mode": 0}}
+        mock_coordinator.data.modules = {
+            module_id: IndygoModuleData(
+                id=module_id,
+                type="lr-pc",
+                name="Pump",
+                filtration_program=filtration_program,
+            )
+        }
+
+        entity = IndygoPoolSelect(mock_coordinator, module_id, "Pump")
+
+        cancel_cb = MagicMock()
+        with patch(
+            "custom_components.indygo_pool.select.async_call_later",
+            return_value=cancel_cb,
+        ):
+            await entity.async_select_option(MODE_ON)
+            # First delayed refresh scheduled, not cancelled yet
+            cancel_cb.assert_not_called()
+
+            await entity.async_select_option(MODE_AUTO)
+            # Previous delayed refresh should have been cancelled
+            cancel_cb.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delayed_refresh_callback(self, mock_coordinator):
+        """Test the delayed refresh callback triggers a coordinator refresh."""
+        module_id = "mod1"
+        mock_coordinator.data.modules = {
+            module_id: IndygoModuleData(
+                id=module_id,
+                type="lr-pc",
+                name="Pump",
+                filtration_program={"programCharacteristics": {"mode": 0}},
+            )
+        }
+
+        entity = IndygoPoolSelect(mock_coordinator, module_id, "Pump")
+
+        with patch(
+            "custom_components.indygo_pool.select.async_call_later"
+        ) as mock_call_later:
+            await entity.async_select_option(MODE_ON)
+
+        # Extract and call the delayed refresh callback
+        callback = mock_call_later.call_args[0][2]
+        mock_coordinator.async_request_refresh.reset_mock()
+        await callback(None)
+
+        mock_coordinator.async_request_refresh.assert_called_once()
+        assert entity._cancel_delayed_refresh is None
 
     @pytest.mark.asyncio
     async def test_select_option_invalid(self, mock_coordinator):


### PR DESCRIPTION
## Summary

- After a filtration mode change (Off/On/Auto), the device status wasn't updated immediately because the command travels through cloud → gateway → LoRa → device
- Added a follow-up coordinator refresh 10 seconds after the mode change using `async_call_later` to capture the updated device state
- If the user changes mode again before the 10s delay, the previous timer is cancelled to avoid unnecessary refreshes

## Test plan

- [x] Unit tests cover the delayed refresh scheduling, cancellation, and callback execution
- [x] `select.py` at 100% coverage
- [x] Manual test: change filtration mode and verify the binary sensor updates within ~10s