### PR TITLE
Fix/pool status

### DIFF
--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -253,6 +253,12 @@ class IndygoPoolApiClient:
         )
         return data.get("programs", [])
 
+    async def _fetch_pool_status(self) -> dict:
+        """Fetch pool status via /api/getPoolStatus."""
+        return await self._api_post(
+            "/api/getPoolStatus",  {"id": self._pool_id}
+        )
+
     async def _resolve_hardware_ids(self, modules: list[dict]) -> None:
         """Resolve pool_address, device_short_id and relay_id from modules."""
         if self._pool_address and self._device_short_id and self._relay_id:
@@ -291,15 +297,7 @@ class IndygoPoolApiClient:
         await asyncio.gather(*[_attach_programs(m) for m in modules])
 
         # 4. Fetch live status data from the device endpoint
-        url = (
-            f"{BASE_URL}/v1/module/{self._pool_address}/status/{self._device_short_id}"
-        )
-        status_data = await self._request(
-            "GET",
-            url,
-            headers={"x-requested-with": "XMLHttpRequest"},
-            return_json=True,
-        )
+        status_data = await self._fetch_pool_status()
 
         # 5. Merge modules metadata into the status data
         status_data["modules"] = modules

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -291,7 +291,7 @@ class IndygoParser:
         """Parse root level sensors."""
         root_sensors_map = {
             "temperature": {
-                "attributes": {"temperatureTime": "last_measurement_time"},
+                "attributes": {"date": "last_measurement_time"},
             },
         }
 
@@ -299,15 +299,16 @@ class IndygoParser:
 
         for key, config in root_sensors_map.items():
             if key in json_data and json_data[key] is not None:
+                temperature = json_data[key]
                 extra_attributes = {}
                 attr_map = config.get("attributes", {})
                 for source_key, target_key in attr_map.items():
-                    if source_key in json_data:
-                        extra_attributes[target_key] = json_data[source_key]
+                    if source_key in temperature:
+                        extra_attributes[target_key] = temperature[source_key]
 
                 target_sensors[key] = IndygoSensorData(
                     key=key,
-                    value=json_data[key],
+                    value=temperature["value"],
                     extra_attributes=extra_attributes,
                 )
 


### PR DESCRIPTION
First of all, I know this PR does not respect contributing guidelines.

This PR is a proposal to replace /v1/module API call with `getPoolStatus` to fetch pool status, as /v1/module seems not to reliable.

This PR does not cover the tests as my knowledge of all of this is too bad.

On my HA, it unlocks me from 408 error when adding the module (fixes #31).

