### PR TITLE
feat: add diagnostics platform for hardware discovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -59,3 +59,13 @@ body:
             custom_components.indygo_pool: debug
         ```
       render: yaml
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Go to **Settings → Devices & Services → Indygo Pool → ⋮ → Download diagnostics** and paste the JSON content here.
+        This helps identify your hardware without needing physical access to it.
+
+        > **Before sharing:** review the JSON and remove any information you consider sensitive (module names, serial numbers, location data, etc.). The integration filters common PII fields, but it cannot know what is confidential for you.
+      render: json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,18 @@ Then run the integration tests using:
 uv run pytest -s -m integration tests
 ```
 
+### Sharing Diagnostics
+
+When reporting a bug or requesting support for unknown hardware, include the integration diagnostics:
+
+1. Go to **Settings → Devices & Services → Indygo Pool**
+2. Click the **⋮** menu → **Download diagnostics**
+3. Attach the JSON to your GitHub issue
+
+The diagnostics include raw module data (`inputs`, `outputs`, `ipxData`) that reveals what sensors and controls each hardware device exposes, without requiring physical access to the hardware.
+
+> **Before sharing:** review the JSON and remove anything you consider sensitive. The integration filters common PII fields (email, address, coordinates, MAC address, etc.), but cannot determine what is confidential for you.
+
 ### Manual Config Testing (Docker)
 1. Start the Home Assistant container: `docker compose up -d`
 2. Access Home Assistant at [http://localhost:8123](http://localhost:8123).

--- a/custom_components/indygo_pool/diagnostics.py
+++ b/custom_components/indygo_pool/diagnostics.py
@@ -1,0 +1,91 @@
+"""Diagnostics support for Indygo Pool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN
+
+_CONFIG_TO_REDACT = {CONF_EMAIL, CONF_PASSWORD}
+
+# Keys containing personal information — replaced with **REDACTED**.
+_RAW_TO_REDACT = frozenset(
+    {
+        "owner",
+        "address",
+        "latitude",
+        "longitude",
+        "macAddress",
+        "uuid",
+        "adminUsers",
+        "garden",
+        "locationKey",
+        "simcard",
+    }
+)
+
+# Bulky, location-revealing keys that obscure the useful data — dropped entirely.
+_NOISE_KEYS = frozenset(
+    {
+        "addressWeather",
+        "dailyWeatherForecast",
+        "daylyWeatherForecast",
+        "hourlyWeatherForecast",
+        "weeklyWeatherForecast",
+    }
+)
+
+# Extra keys to drop from pool_data.raw_data (already surfaced via "modules").
+_RAW_STATUS_SKIP = _NOISE_KEYS | {"modules", "ipx_module"}
+
+
+def _sanitize(raw: dict, skip: frozenset[str]) -> dict:
+    return {k: v for k, v in raw.items() if k not in skip}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    client = coordinator.client
+    pool_data = coordinator.data
+
+    modules_info: list[dict[str, Any]] = []
+    if pool_data:
+        for module in pool_data.modules.values():
+            raw = module.raw_data or {}
+            modules_info.append(
+                async_redact_data(_sanitize(raw, _NOISE_KEYS), _RAW_TO_REDACT)
+                | {
+                    "sensors": list(module.sensors.keys()),
+                    "pool_status_circuits": list(module.pool_status.keys()),
+                    "has_filtration_program": module.filtration_program is not None,
+                }
+            )
+
+    raw_status: dict[str, Any] = {}
+    if pool_data and pool_data.raw_data:
+        raw_status = async_redact_data(
+            _sanitize(pool_data.raw_data, _RAW_STATUS_SKIP),
+            _RAW_TO_REDACT,
+        )
+
+    return {
+        "config_entry": async_redact_data(dict(entry.data), _CONFIG_TO_REDACT),
+        "hardware_ids": {
+            "pool_address": client._pool_address,
+            "device_short_id": client._device_short_id,
+            "relay_id": client._relay_id,
+        },
+        "modules": modules_info,
+        "root_sensors": list(pool_data.sensors.keys()) if pool_data else [],
+        "root_pool_status_circuits": (
+            list(pool_data.pool_status.keys()) if pool_data else []
+        ),
+        "raw_status": raw_status,
+    }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,216 @@
+"""Tests for Indygo Pool diagnostics."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.indygo_pool.const import (
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    CONF_POOL_ID,
+    DOMAIN,
+)
+from custom_components.indygo_pool.diagnostics import async_get_config_entry_diagnostics
+from custom_components.indygo_pool.models import (
+    IndygoModuleData,
+    IndygoPoolData,
+    IndygoSensorData,
+)
+
+TEST_POOL_ID = "pool_diag_001"
+TEST_POOL_ADDRESS = "SERIAL_GW_001"
+TEST_DEVICE_SHORT_ID = "ABCDEF"
+TEST_RELAY_ID = "relay_mock_001"
+
+TEST_TEMP_VALUE = 28.5
+TEST_PH_VALUE = 7.2
+TEST_LRPC_INPUT_TYPE = 5
+TEST_IPX_INPUT_TYPE = 6
+TEST_SENSOR_STATE_RAW = 2850
+
+
+def _make_coordinator(pool_data: IndygoPoolData | None) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.data = pool_data
+    coordinator.client._pool_address = TEST_POOL_ADDRESS
+    coordinator.client._device_short_id = TEST_DEVICE_SHORT_ID
+    coordinator.client._relay_id = TEST_RELAY_ID
+    return coordinator
+
+
+def _make_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "s3cr3t",
+            CONF_POOL_ID: TEST_POOL_ID,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_full(hass):
+    """Verify PII redaction, noise removal, and novel-field passthrough."""
+    entry = _make_entry()
+
+    pool_data = IndygoPoolData(
+        pool_id=TEST_POOL_ID,
+        raw_data={
+            "temperature": TEST_TEMP_VALUE,
+            "temperatureTime": "2023-01-01T12:00:00Z",
+            "sensorState": [{"index": 0, "value": TEST_SENSOR_STATE_RAW}],
+            "pool": [{"index": 0, "value": 1}],
+            # Must be dropped (noise)
+            "addressWeather": {"cityName": "TestCity"},
+            # Unknown future field — must pass through unchanged
+            "futureUnknownField": "some_value",
+        },
+    )
+    pool_data.modules["lrpc_1"] = IndygoModuleData(
+        id="lrpc_1",
+        type="lr-pc",
+        name="LRPC-ABCDEF",
+        sensors={
+            "temperature": IndygoSensorData(key="temperature", value=TEST_TEMP_VALUE)
+        },
+        raw_data={
+            "type": "lr-pc",
+            "name": "LRPC-ABCDEF",
+            "serialNumber": "SERIAL_LRPC_001",
+            "softwareVersion": "7.0.9",
+            "hardwareVersion": "B",
+            "manufacturerType": "15",
+            "defaultName": "LRPC3-ABCDEF",
+            # PII — must be redacted
+            "owner": "user_object_id_123",
+            "macAddress": "C8:B9:61:F1:E8:1E",
+            # Novel hardware field — must pass through
+            "vs2CustomField": "vs2value",
+            # Noise — must be dropped
+            "addressWeather": {"cityName": "TestCity"},
+            # Raw inputs/outputs for hardware discovery
+            "inputs": [
+                {
+                    "type": TEST_LRPC_INPUT_TYPE,
+                    "subType": 0,
+                    "unit": 2,
+                    "expression": "x/100.0",
+                    "name": "",
+                    "lastValue": {
+                        "value": TEST_TEMP_VALUE,
+                        "date": "2023-01-01T12:00:00Z",
+                    },
+                }
+            ],
+            "outputs": [{"index": 0, "name": "Station 1", "useSensor": True}],
+        },
+    )
+    pool_data.modules["ipx_1"] = IndygoModuleData(
+        id="ipx_1",
+        type="ipx",
+        name="IPX-MOCK",
+        sensors={
+            "ph": IndygoSensorData(key="ph", value=TEST_PH_VALUE),
+            "ipx_salt": IndygoSensorData(key="ipx_salt", value=4.5),
+        },
+        raw_data={
+            "type": "ipx",
+            "name": "IPX-MOCK",
+            "serialNumber": "SERIAL_IPX_001",
+            "softwareVersion": "0.0",
+            "hardwareVersion": "0",
+            "manufacturerType": "FD",
+            "defaultName": "IPX2-MOCK",
+            "inputs": [
+                {
+                    "type": TEST_IPX_INPUT_TYPE,
+                    "subType": 0,
+                    "unit": 4,
+                    "expression": "x/100.0",
+                    "name": "",
+                    "lastValue": {
+                        "value": TEST_PH_VALUE,
+                        "date": "2023-01-01T12:37:00Z",
+                    },
+                }
+            ],
+            "outputs": [
+                {
+                    "index": 0,
+                    "name": "Station 1",
+                    "useSensor": True,
+                    "ipxData": {
+                        "type": 1,
+                        "pHSetpoint": TEST_PH_VALUE,
+                        "pHHysteresis": 0.1,
+                    },
+                }
+            ],
+        },
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(pool_data)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Config entry: credentials redacted, pool_id intact
+    assert result["config_entry"][CONF_POOL_ID] == TEST_POOL_ID
+    assert result["config_entry"][CONF_EMAIL] == "**REDACTED**"
+    assert result["config_entry"][CONF_PASSWORD] == "**REDACTED**"
+
+    # Hardware IDs
+    assert result["hardware_ids"]["pool_address"] == TEST_POOL_ADDRESS
+    assert result["hardware_ids"]["device_short_id"] == TEST_DEVICE_SHORT_ID
+    assert result["hardware_ids"]["relay_id"] == TEST_RELAY_ID
+
+    assert len(result["modules"]) == len(pool_data.modules)
+    lrpc = next(m for m in result["modules"] if m["type"] == "lr-pc")
+
+    # PII redacted
+    assert lrpc["owner"] == "**REDACTED**"
+    assert lrpc["macAddress"] == "**REDACTED**"
+
+    # Novel/unknown field passes through — essential for unsupported hardware
+    assert lrpc["vs2CustomField"] == "vs2value"
+
+    # Noise dropped
+    assert "addressWeather" not in lrpc
+
+    # Computed metadata present
+    assert "temperature" in lrpc["sensors"]
+    assert lrpc["has_filtration_program"] is False
+
+    # Raw inputs present with full detail for hardware discovery
+    assert lrpc["inputs"][0]["type"] == TEST_LRPC_INPUT_TYPE
+    assert lrpc["inputs"][0]["lastValue"]["value"] == TEST_TEMP_VALUE
+
+    # Raw outputs present
+    assert lrpc["outputs"][0]["index"] == 0
+
+    # IPX module: ipxData inside outputs
+    ipx = next(m for m in result["modules"] if m["type"] == "ipx")
+    assert ipx["outputs"][0]["ipxData"]["pHSetpoint"] == TEST_PH_VALUE
+    assert "ph" in ipx["sensors"]
+    assert "ipx_salt" in ipx["sensors"]
+
+    # Root-level raw status: useful fields pass through, noise dropped
+    assert result["raw_status"]["temperature"] == TEST_TEMP_VALUE
+    assert result["raw_status"]["sensorState"][0]["value"] == TEST_SENSOR_STATE_RAW
+    assert result["raw_status"]["futureUnknownField"] == "some_value"
+    assert "addressWeather" not in result["raw_status"]
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_no_data(hass):
+    """Test diagnostics when coordinator has no data yet."""
+    entry = _make_entry()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(None)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["modules"] == []
+    assert result["root_sensors"] == []
+    assert result["root_pool_status_circuits"] == []
+    assert result["raw_status"] == {}


### PR DESCRIPTION
## Motivation

Contributors reporting issues with unsupported hardware (VS2, unknown IPX variants, etc.) couldn't share actionable data because there was no structured way to capture what their hardware actually exposes. This adds a HA diagnostics endpoint that surfaces the raw API payloads so hardware can be understood without physical access.

## What this adds

- `diagnostics.py`: implements `async_get_config_entry_diagnostics`, dumping full raw module data (`inputs`, `outputs`, `ipxData`, programs, firmware versions, etc.) plus the status response snapshot.
- PII redaction via `async_redact_data` (owner, address, coordinates, MAC, uuid). Bulky noise (weather forecasts) stripped entirely. Unknown fields pass through unchanged — intentional, this is the mechanism that makes it useful for novel hardware.
- Bug report template: new optional `Diagnostics` field with instructions and a privacy reminder.
- `CONTRIBUTING.md`: new "Sharing Diagnostics" section with the same instructions and reminder.

## Notes

- Pool-level config fields from `getPoolStatus` (`waterTreatmentType`, `model`, `moduleTypesLinked`, etc.) are not captured here because that endpoint is not called on `main`. This can follow once PR #142 lands.
- `serialNumber` is intentionally not redacted: it is already used as the hardware identifier in logs and needed for cross-referencing.