### PR TITLE
fix: replace /v1/module with getPoolStatus and redact installer PII in diagnostics

### DIFF
--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -257,6 +257,22 @@ class IndygoPoolApiClient:
         """Fetch pool status via /api/getPoolStatus."""
         return await self._api_post("/api/getPoolStatus", {"id": self._pool_id})
 
+    async def _fetch_device_status(self) -> dict:
+        """Fetch live device status via /v1/module (pump circuits, sensorState).
+
+        Some hardware returns 408 — callers must handle
+        IndygoPoolApiClientCommunicationError.
+        """
+        url = (
+            f"{BASE_URL}/v1/module/{self._pool_address}/status/{self._device_short_id}"
+        )
+        return await self._request(
+            "GET",
+            url,
+            headers={"x-requested-with": "XMLHttpRequest"},
+            return_json=True,
+        )
+
     async def _resolve_hardware_ids(self, modules: list[dict]) -> None:
         """Resolve pool_address, device_short_id and relay_id from modules."""
         if self._pool_address and self._device_short_id and self._relay_id:
@@ -294,8 +310,21 @@ class IndygoPoolApiClient:
 
         await asyncio.gather(*[_attach_programs(m) for m in modules])
 
-        # 4. Fetch live status data from the device endpoint
+        # 4. Fetch pool status (works for all hardware)
         status_data = await self._fetch_pool_status()
+
+        # 4b. Merge pump circuit data from device endpoint when available.
+        # Some hardware returns 408 — skip gracefully in that case.
+        try:
+            device_status = await self._fetch_device_status()
+            for key in ("pool", "sensorState", "dialogTimeStamp"):
+                if key in device_status:
+                    status_data[key] = device_status[key]
+        except IndygoPoolApiClientCommunicationError:
+            LOGGER.debug(
+                "Device status endpoint unavailable for %s — pump circuits skipped",
+                self._pool_address,
+            )
 
         # 5. Merge modules metadata into the status data
         status_data["modules"] = modules

--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -255,9 +255,7 @@ class IndygoPoolApiClient:
 
     async def _fetch_pool_status(self) -> dict:
         """Fetch pool status via /api/getPoolStatus."""
-        return await self._api_post(
-            "/api/getPoolStatus",  {"id": self._pool_id}
-        )
+        return await self._api_post("/api/getPoolStatus", {"id": self._pool_id})
 
     async def _resolve_hardware_ids(self, modules: list[dict]) -> None:
         """Resolve pool_address, device_short_id and relay_id from modules."""

--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -253,6 +253,12 @@ class IndygoPoolApiClient:
         )
         return data.get("programs", [])
 
+    async def _fetch_pool_status(self) -> dict:
+        """Fetch pool status via /api/getPoolStatus."""
+        return await self._api_post(
+            "/api/getPoolStatus",  {"id": self._pool_id}
+        )
+
     async def _resolve_hardware_ids(self, modules: list[dict]) -> None:
         """Resolve pool_address, device_short_id and relay_id from modules."""
         if self._pool_address and self._device_short_id and self._relay_id:
@@ -291,15 +297,7 @@ class IndygoPoolApiClient:
         await asyncio.gather(*[_attach_programs(m) for m in modules])
 
         # 4. Fetch live status data from the device endpoint
-        url = (
-            f"{BASE_URL}/v1/module/{self._pool_address}/status/{self._device_short_id}"
-        )
-        status_data = await self._request(
-            "GET",
-            url,
-            headers={"x-requested-with": "XMLHttpRequest"},
-            return_json=True,
-        )
+        status_data = await self._fetch_pool_status()
 
         # 5. Merge modules metadata into the status data
         status_data["modules"] = modules

--- a/custom_components/indygo_pool/diagnostics.py
+++ b/custom_components/indygo_pool/diagnostics.py
@@ -40,7 +40,7 @@ _NOISE_KEYS = frozenset(
 )
 
 # Extra keys to drop from pool_data.raw_data (already surfaced via "modules").
-_RAW_STATUS_SKIP = _NOISE_KEYS | {"modules", "ipx_module"}
+_RAW_STATUS_SKIP = _NOISE_KEYS | {"modules", "ipx_module", "professional", "agency"}
 
 
 def _sanitize(raw: dict, skip: frozenset[str]) -> dict:

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -291,7 +291,7 @@ class IndygoParser:
         """Parse root level sensors."""
         root_sensors_map = {
             "temperature": {
-                "attributes": {"temperatureTime": "last_measurement_time"},
+                "attributes": {"date": "last_measurement_time"},
             },
         }
 
@@ -299,15 +299,16 @@ class IndygoParser:
 
         for key, config in root_sensors_map.items():
             if key in json_data and json_data[key] is not None:
+                temperature = json_data[key]
                 extra_attributes = {}
                 attr_map = config.get("attributes", {})
                 for source_key, target_key in attr_map.items():
-                    if source_key in json_data:
-                        extra_attributes[target_key] = json_data[source_key]
+                    if source_key in temperature:
+                        extra_attributes[target_key] = temperature[source_key]
 
                 target_sensors[key] = IndygoSensorData(
                     key=key,
-                    value=json_data[key],
+                    value=temperature["value"],
                     extra_attributes=extra_attributes,
                 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -179,9 +179,9 @@ async def test_get_data_success():
             payload={"programs": []},
         )
         # Mock status data
-        m.get(
-            f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/ABC",
-            payload={"temperature": 25.5},
+        m.post(
+            f"{BASE_URL}/api/getPoolStatus",
+            payload={"temperature": {"date": "2023-01-01T12:00:00Z", "value": 25.5}},
         )
 
         async with aiohttp.ClientSession() as session:
@@ -221,18 +221,12 @@ async def test_get_data_resolves_hardware_ids_once():
         m.post(f"{BASE_URL}/api/getUserWithHisModules", payload=MODULES_RESPONSE)
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
-        m.get(
-            f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/ABC",
-            payload={},
-        )
+        m.post(f"{BASE_URL}/api/getPoolStatus", payload={})
         # Second call
         m.post(f"{BASE_URL}/api/getUserWithHisModules", payload=MODULES_RESPONSE)
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
-        m.get(
-            f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/ABC",
-            payload={},
-        )
+        m.post(f"{BASE_URL}/api/getPoolStatus", payload={})
 
         async with aiohttp.ClientSession() as session:
             client = _make_client(session)
@@ -478,7 +472,7 @@ async def test_auto_refresh_on_401():
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         # Status
-        m.get(f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/ABC", payload={})
+        m.post(f"{BASE_URL}/api/getPoolStatus", payload={})
 
         async with aiohttp.ClientSession() as session:
             client = _make_client(session)
@@ -589,7 +583,7 @@ async def test_get_data_with_ipx_module():
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
         m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
-        m.get(f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/ABC", payload={})
+        m.post(f"{BASE_URL}/api/getPoolStatus", payload={})
 
         async with aiohttp.ClientSession() as session:
             client = _make_client(session)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,25 @@ async def test_api_client_authentication():
         assert isinstance(data, IndygoPoolData)
         assert data.pool_id == pool_id
 
+        # At least one module must be present
+        assert len(data.modules) > 0
+
+        # Filtration module checks
+        filt_modules = [
+            m for m in data.modules.values() if m.filtration_program is not None
+        ]
+        if filt_modules:
+            filt_mod = filt_modules[0]
+            assert "temperature" in filt_mod.sensors, (
+                "Filtration module missing temperature"
+            )
+            # pool_status populated when /v1/module is reachable
+            assert "0" in filt_mod.pool_status, (
+                "Filtration module missing pool_status"
+                " — /v1/module fallback may have failed"
+            )
+            assert "filtration_remaining_time" in filt_mod.sensors
+
 
 # ---------------------------------------------------------------------------
 # Login tests
@@ -710,3 +729,92 @@ async def test_set_filtration_mode_invalid_program():
         bad_program = {"id": "prog_bad"}
         with pytest.raises(IndygoPoolApiClientError, match="programCharacteristics"):
             await client.async_set_filtration_mode(TEST_MODULE_ID, bad_program, 1)
+
+
+# ---------------------------------------------------------------------------
+# Device status fallback tests
+# ---------------------------------------------------------------------------
+
+# device_short_id = last segment of lr-pc name ("Pump-ABC" → "ABC")
+_LR_PC_DEVICE_SHORT_ID = MODULES_RESPONSE["modules"][0]["name"].split("-")[-1]
+DEVICE_STATUS_URL = (
+    f"{BASE_URL}/v1/module/{TEST_POOL_ADDRESS}/status/{_LR_PC_DEVICE_SHORT_ID}"
+)
+
+
+@pytest.mark.asyncio
+async def test_get_data_device_status_merged():
+    """pool/sensorState from /v1/module are merged into parsed data when available."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    with aioresponses() as m:
+        m.post(f"{BASE_URL}/api/getUserWithHisModules", payload=MODULES_RESPONSE)
+        m.post(
+            f"{BASE_URL}/api/getModuleWithHisPrograms",
+            payload={
+                "programs": [{"programCharacteristics": {"programType": 4, "mode": 2}}]
+            },
+        )
+        m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
+        m.post(
+            f"{BASE_URL}/api/getPoolStatus",
+            payload={"temperature": {"date": "2023-01-01T12:00:00Z", "value": 25.5}},
+        )
+        m.get(
+            DEVICE_STATUS_URL,
+            payload={
+                "pool": [
+                    {"index": 0, "value": 1, "info": "Filtration", "time": "02:30"}
+                ],
+                "sensorState": [{"index": 0, "value": 2500}],
+            },
+        )
+
+        async with aiohttp.ClientSession() as session:
+            client = _make_client(session)
+            data = await client.async_get_data()
+
+        filt_mod = data.modules[TEST_MODULE_ID]
+        assert "0" in filt_mod.pool_status, (
+            "pool_status missing — /v1/module data not merged"
+        )
+        # sensorState [{"index": 0, "value": 2500}] → 25.0°C
+        expected_temp_merged = 2500 / 100.0
+        assert filt_mod.pool_status["0"].value == 1
+        assert filt_mod.sensors["temperature"].value == expected_temp_merged
+        assert "filtration_remaining_time" in filt_mod.sensors
+
+
+@pytest.mark.asyncio
+async def test_get_data_device_status_408_no_crash():
+    """408 from /v1/module is silently skipped — no pool_status, no exception."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    with aioresponses() as m:
+        m.post(f"{BASE_URL}/api/getUserWithHisModules", payload=MODULES_RESPONSE)
+        m.post(
+            f"{BASE_URL}/api/getModuleWithHisPrograms",
+            payload={
+                "programs": [{"programCharacteristics": {"programType": 4, "mode": 2}}]
+            },
+        )
+        m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
+        m.post(
+            f"{BASE_URL}/api/getPoolStatus",
+            payload={"temperature": {"date": "2023-01-01T12:00:00Z", "value": 24.96}},
+        )
+        m.get(DEVICE_STATUS_URL, status=408)
+
+        async with aiohttp.ClientSession() as session:
+            client = _make_client(session)
+            data = await client.async_get_data()
+
+        filt_mod = data.modules[TEST_MODULE_ID]
+        assert filt_mod.pool_status == {}, (
+            "pool_status should be empty when /v1/module returns 408"
+        )
+        # temperature from getPoolStatus dict format
+        expected_temp_fallback = 24.96
+        assert filt_mod.sensors["temperature"].value == expected_temp_fallback

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,13 @@ TEST_DATE = "2023-01-01T12:00:00Z"
 FILTRATION_PROGRAM_TYPE = 4
 MODE_AUTO = 2
 MODE_ON = 1
+# Constants for getPoolStatus hardware variant (lr-mb-10 + lr-pc-vs2 + ipx)
+TEST_TEMP_IPX = 24.96
+TEST_ELECTROLYSIS_IPX = 209
+TEST_PH_IPX = 7.3
+TEST_SALT_IPX = 3.3
+TEST_PH_SETPOINT_IPX = 7.2
+TEST_PROD_SETPOINT_IPX = 100
 
 
 class TestIndygoParser:
@@ -85,8 +92,7 @@ class TestIndygoParser:
         """Test parsing API JSON into IndygoPoolData."""
         parser = IndygoParser()
         json_data = {
-            "temperature": TEST_TEMP_VALUE,
-            "temperatureTime": TEST_DATE,
+            "temperature": {"date": TEST_DATE, "value": TEST_TEMP_VALUE},
             "sensorState": [{"index": 0, "value": TEST_SENSOR_STATE_TEMP}],
             "ph": TEST_PH_VALUE,
             "modules": [
@@ -552,6 +558,90 @@ class TestIndygoParser:
             "RELAY1",
         )
         assert "ipx_salt" not in data.sensors
+
+    def test_parse_data_getpoolstatus_format(self):
+        """Test parsing getPoolStatus response: temperature as dict, no sensorState.
+
+        Represents hardware: lr-mb-10 + lr-pc-vs2 + ipx (reported by contributor
+        ugorenner — anonymized). getPoolStatus returns temperature as
+        {"date": ..., "value": ...} with no sensorState array.
+        """
+        parser = IndygoParser()
+        json_data = {
+            "temperature": {"date": TEST_DATE, "value": TEST_TEMP_IPX},
+            "modules": [
+                {
+                    "id": "GW1",
+                    "type": "lr-mb-10",
+                    "name": "Gateway",
+                    "serialNumber": "GW_SERIAL",
+                },
+                {
+                    "id": "PUMP1",
+                    "type": "lr-pc-vs2",
+                    "name": "Pool Pump",
+                    "relay": "RELAY_ID",
+                    "programs": [
+                        {
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_AUTO,
+                            }
+                        }
+                    ],
+                },
+                {
+                    "id": "IPX1",
+                    "type": "ipx",
+                    "name": "Electrolyzer",
+                    "ipxData": {"totalElectrolyseDuration": TEST_ELECTROLYSIS_IPX},
+                },
+            ],
+            "ipx_module": {
+                "outputs": [
+                    {"ipxData": {"pHSetpoint": TEST_PH_SETPOINT_IPX}},
+                    {
+                        "ipxData": {
+                            "saltValue": TEST_SALT_IPX,
+                            "percentageSetpoint": TEST_PROD_SETPOINT_IPX,
+                            "electrolyzerMode": MODE_AUTO,
+                        }
+                    },
+                ],
+                "inputs": [
+                    {"name": "", "type": 0},
+                    {
+                        "name": "",
+                        "type": 6,
+                        "lastValue": {"value": TEST_PH_IPX, "date": TEST_DATE},
+                    },
+                ],
+            },
+        }
+
+        pool_data = parser.parse_data(json_data, "POOL1", "GW_SERIAL", "RELAY_ID")
+
+        # Temperature populates on filtration module (lr-pc-vs2) from dict format
+        assert "PUMP1" in pool_data.modules
+        pump_mod = pool_data.modules["PUMP1"]
+        assert pump_mod.sensors["temperature"].value == TEST_TEMP_IPX
+        assert (
+            pump_mod.sensors["temperature"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+        assert pump_mod.filtration_program is not None
+
+        # pool_status_circuits empty (no pool/sensorState in getPoolStatus response)
+        assert pump_mod.pool_status == {}
+        assert pool_data.pool_status == {}
+
+        # IPX sensors populated
+        assert "IPX1" in pool_data.modules
+        ipx_mod = pool_data.modules["IPX1"]
+        electrolysis_val = ipx_mod.sensors["totalElectrolyseDuration"].value
+        assert electrolysis_val == TEST_ELECTROLYSIS_IPX
+        assert ipx_mod.sensors["ph"].value == TEST_PH_IPX
+        assert ipx_mod.sensors["ipx_salt"].value == TEST_SALT_IPX
 
 
 class TestGetNested:


### PR DESCRIPTION
Fixes #31. Cherry-picked from #142 (contributed by @ugorenner) with tests and a diagnostics fix on top.

`/v1/module` returns 408 for hardware setups where the pump controller communicates via radio relay (`lr-mb-10` + `lr-pc-vs2`). `getPoolStatus` works for all confirmed setups and returns the same data. Validated against two real accounts (lr-pc and lr-mb-10 + lr-pc-vs2 + ipx hardware).

The `professional` and `agency` keys in `getPoolStatus` responses contained installer contact data that was not being redacted in the diagnostics dump. Dropped entirely since they carry no diagnostic value.

Closes #142.