### PR TITLE
feat: add Redox and filter pressure sensors from module inputs

### DIFF
--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -12,7 +12,17 @@ from .models import IndygoModuleData, IndygoPoolData, IndygoSensorData
 _LOGGER = logging.getLogger(__name__)
 
 
-IPX_PH_SENSOR_TYPE = 6
+INPUT_SENSOR_TYPE_PH = 6
+INPUT_SENSOR_TYPE_REDOX = 7
+INPUT_SENSOR_TYPE_PRESSURE = 8
+INPUT_SENSOR_TYPE_PRESSURE_ALT = 56
+
+INPUT_SENSOR_TYPES = {
+    INPUT_SENSOR_TYPE_PH: "ph",
+    INPUT_SENSOR_TYPE_REDOX: "redox",
+    INPUT_SENSOR_TYPE_PRESSURE: "filter_pressure",
+    INPUT_SENSOR_TYPE_PRESSURE_ALT: "filter_pressure",
+}
 
 
 def _get_nested(obj: dict | list | None, *keys: str) -> Any:
@@ -37,6 +47,13 @@ class IndygoParser:
     # Hardware ID resolution (from module list, no HTML needed)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_lr_pc_module(module: dict | IndygoModuleData) -> bool:
+        """Return true for Pool Command modules, including VS variants."""
+        if isinstance(module, IndygoModuleData):
+            return module.type.startswith("lr-pc")
+        return module.get("type", "").startswith("lr-pc")
+
     def _extract_device_ids(self, lr_pc: dict) -> tuple[str | None, str | None]:
         """Extract device short ID and relay ID from lr-pc module."""
         name_parts = lr_pc.get("name", "").split("-")
@@ -53,7 +70,7 @@ class IndygoParser:
     ) -> tuple[str | None, str | None, str | None]:
         """Resolve IDs from lr-pc + gateway modules."""
         gateway = next((m for m in modules if m.get("type") == "lr-mb-10"), None)
-        lr_pc = next((m for m in modules if m.get("type") == "lr-pc"), None)
+        lr_pc = next((m for m in modules if self._is_lr_pc_module(m)), None)
 
         if not lr_pc:
             return None, None, None
@@ -110,7 +127,14 @@ class IndygoParser:
         """Find the module responsible for filtration."""
         return next(
             (m for m in pool_data.modules.values() if m.filtration_program),
-            next((m for m in pool_data.modules.values() if m.type == "lr-pc"), None),
+            next(
+                (
+                    m
+                    for m in pool_data.modules.values()
+                    if IndygoParser._is_lr_pc_module(m)
+                ),
+                None,
+            ),
         )
 
     def parse_data(
@@ -367,6 +391,8 @@ class IndygoParser:
                         )
                     )
 
+            self._parse_input_sensors(module.get("inputs", []), indygo_module.sensors)
+
             # Programs
             programs = module.get("programs", [])
             if programs:
@@ -381,6 +407,35 @@ class IndygoParser:
                         break
 
             pool_data.modules[str(m_id)] = indygo_module
+
+    @staticmethod
+    def _parse_input_sensors(
+        inputs: list[dict],
+        target_sensors: dict[str, IndygoSensorData],
+    ) -> None:
+        """Parse generic module input sensors."""
+        if not isinstance(inputs, list):
+            return
+
+        for inp in inputs:
+            sensor_key = INPUT_SENSOR_TYPES.get(inp.get("type"))
+            if not sensor_key:
+                continue
+
+            last_measure = inp.get("lastValue") or inp.get("lastComputedMeasure")
+            if not isinstance(last_measure, dict) or last_measure.get("value") is None:
+                continue
+
+            extra_attrs = {}
+            date_str = last_measure.get("date")
+            if date_str:
+                extra_attrs["last_measurement_time"] = date_str
+
+            target_sensors[sensor_key] = IndygoSensorData(
+                key=sensor_key,
+                value=last_measure["value"],
+                extra_attributes=extra_attrs,
+            )
 
     def _parse_scraped_ipx(self, json_data: dict, pool_data: IndygoPoolData) -> None:
         """Parse ipx_module data."""
@@ -419,23 +474,4 @@ class IndygoParser:
                 value=elec_mode,
             )
 
-        # pH Latest (from inputs)
-        inputs = ipx_mod.get("inputs", [])
-        if isinstance(inputs, list):
-            for inp in inputs:
-                last_val = inp.get("lastValue")
-                if last_val and "value" in last_val and last_val["value"] is not None:
-                    if inp.get("type") == IPX_PH_SENSOR_TYPE:
-                        val = last_val["value"]
-                        date_str = last_val.get("date")
-
-                        extra_attrs = {}
-                        if date_str:
-                            extra_attrs["last_measurement_time"] = date_str
-
-                        target_sensors["ph"] = IndygoSensorData(
-                            key="ph",
-                            value=val,
-                            extra_attributes=extra_attrs,
-                        )
-                        break
+        self._parse_input_sensors(ipx_mod.get("inputs", []), target_sensors)

--- a/custom_components/indygo_pool/sensor.py
+++ b/custom_components/indygo_pool/sensor.py
@@ -12,7 +12,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfElectricPotential,
+    UnitOfPressure,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify
@@ -74,6 +80,19 @@ SENSOR_TYPES: tuple[IndygoSensorEntityDescription, ...] = (
         translation_key="ph",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+    ),
+    IndygoSensorEntityDescription(
+        key="redox",
+        translation_key="redox",
+        native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    IndygoSensorEntityDescription(
+        key="filter_pressure",
+        translation_key="filter_pressure",
+        native_unit_of_measurement=UnitOfPressure.BAR,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     IndygoSensorEntityDescription(
         key="filtration_remaining_time",

--- a/custom_components/indygo_pool/strings.json
+++ b/custom_components/indygo_pool/strings.json
@@ -45,6 +45,12 @@
             },
             "ph": {
                 "name": "pH"
+            },
+            "redox": {
+                "name": "Redox"
+            },
+            "filter_pressure": {
+                "name": "Filter pressure"
             }
         },
         "binary_sensor": {

--- a/custom_components/indygo_pool/translations/en.json
+++ b/custom_components/indygo_pool/translations/en.json
@@ -45,6 +45,12 @@
             "ph": {
                 "name": "pH"
             },
+            "redox": {
+                "name": "Redox"
+            },
+            "filter_pressure": {
+                "name": "Filter pressure"
+            },
             "filtration_remaining_time": {
                 "name": "Filtration remaining time"
             }

--- a/custom_components/indygo_pool/translations/fr.json
+++ b/custom_components/indygo_pool/translations/fr.json
@@ -45,6 +45,12 @@
             "ph": {
                 "name": "pH"
             },
+            "redox": {
+                "name": "Redox"
+            },
+            "filter_pressure": {
+                "name": "Pression du filtre"
+            },
             "filtration_remaining_time": {
                 "name": "Temps restant filtration"
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ pythonpath = ["."]
 markers = [
     "integration: tests that require real API credentials",
 ]
-addopts = "--cov=custom_components.indygo_pool --cov-report=term-missing --cov-report=xml"
+addopts = "-m 'not integration' --cov=custom_components.indygo_pool --cov-report=term-missing --cov-report=xml"
 
 [tool.coverage.run]
 source = ["custom_components/indygo_pool"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -301,6 +301,24 @@ class TestIndygoParser:
         mod = pool_data.modules["MOD_123"]
         assert mod.sensors["filter_pressure"].value == TEST_PRESSURE_ALT_VALUE
 
+    def test_parse_input_sensors_ignores_non_list_inputs(self):
+        """Test non-list inputs are ignored."""
+        target = {}
+        IndygoParser._parse_input_sensors(None, target)
+        assert target == {}
+
+    def test_parse_input_sensors_skips_invalid_measurements(self):
+        """Test inputs with invalid or missing measurements are skipped."""
+        target = {}
+        IndygoParser._parse_input_sensors(
+            [
+                {"type": 7, "lastValue": "not-a-dict"},
+                {"type": 8, "lastComputedMeasure": {"value": None}},
+            ],
+            target,
+        )
+        assert target == {}
+
     def test_parse_filtration_schedule_as_attributes(self):
         """Test schedule is exposed as attributes on the filtration status."""
         parser = IndygoParser()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -27,6 +27,9 @@ TEST_PH_IPX = 7.3
 TEST_SALT_IPX = 3.3
 TEST_PH_SETPOINT_IPX = 7.2
 TEST_PROD_SETPOINT_IPX = 100
+TEST_REDOX_VALUE = 720
+TEST_PRESSURE_VALUE = 1.2
+TEST_PRESSURE_ALT_VALUE = 1.3
 
 
 class TestIndygoParser:
@@ -44,6 +47,27 @@ class TestIndygoParser:
             {
                 "type": "lr-pc",
                 "serialNumber": "LRPC123",
+                "name": "Pool-ABC",
+                "relay": TEST_RELAY_ID,
+            },
+        ]
+        pool_address, device_short_id, relay_id = parser.resolve_hardware_ids(modules)
+        assert pool_address == TEST_GATEWAY_SERIAL
+        assert device_short_id == TEST_RELAY_ID
+        assert relay_id == TEST_RELAY_ID
+
+    def test_resolve_hardware_ids_lr_pc_vs2(self):
+        """Test resolving hardware IDs from lr-pc-vs2 modules."""
+        parser = IndygoParser()
+        modules = [
+            {
+                "type": "lr-mb-10",
+                "serialNumber": TEST_GATEWAY_SERIAL,
+                "name": "Gateway-01",
+            },
+            {
+                "type": "lr-pc-vs2",
+                "serialNumber": "LRPCVS2123",
                 "name": "Pool-ABC",
                 "relay": TEST_RELAY_ID,
             },
@@ -75,6 +99,14 @@ class TestIndygoParser:
         """Test lr-pc acts as gateway when no dedicated gateway."""
         parser = IndygoParser()
         a, b, c = parser._resolve_lr_pc([{"type": "lr-pc", "serialNumber": "123456"}])
+        assert a == "123456"
+
+    def test_resolve_lr_pc_vs2_acts_as_gateway(self):
+        """Test lr-pc-vs2 acts as gateway when no dedicated gateway."""
+        parser = IndygoParser()
+        a, b, c = parser._resolve_lr_pc(
+            [{"type": "lr-pc-vs2", "serialNumber": "123456"}]
+        )
         assert a == "123456"
 
     def test_resolve_ipx_direct(self):
@@ -202,6 +234,72 @@ class TestIndygoParser:
         assert len(mod.programs) == expected_count
         assert mod.filtration_program is not None
         assert mod.filtration_program["programCharacteristics"]["mode"] == MODE_AUTO
+
+    def test_parse_modules_with_input_sensors(self):
+        """Test Redox and pressure sensors are parsed from module inputs."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD_123",
+                    "type": "lr-pc-vs2",
+                    "name": "Pump",
+                    "inputs": [
+                        {
+                            "type": 7,
+                            "lastValue": {
+                                "value": TEST_REDOX_VALUE,
+                                "date": TEST_DATE,
+                            },
+                        },
+                        {
+                            "type": 8,
+                            "lastComputedMeasure": {
+                                "value": TEST_PRESSURE_VALUE,
+                                "date": TEST_DATE,
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        mod = pool_data.modules["MOD_123"]
+
+        assert mod.sensors["redox"].value == TEST_REDOX_VALUE
+        assert (
+            mod.sensors["redox"].extra_attributes["last_measurement_time"] == TEST_DATE
+        )
+        assert mod.sensors["filter_pressure"].value == TEST_PRESSURE_VALUE
+        assert (
+            mod.sensors["filter_pressure"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+
+    def test_parse_modules_with_alt_pressure_input_sensor(self):
+        """Test alternate pressure input type is parsed."""
+        parser = IndygoParser()
+        json_data = {
+            "modules": [
+                {
+                    "id": "MOD_123",
+                    "type": "lr-pc",
+                    "name": "Pump",
+                    "inputs": [
+                        {
+                            "type": 56,
+                            "lastValue": {
+                                "value": TEST_PRESSURE_ALT_VALUE,
+                                "date": TEST_DATE,
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        pool_data = parser.parse_data(json_data, "P1", "A1", "R1")
+        mod = pool_data.modules["MOD_123"]
+        assert mod.sensors["filter_pressure"].value == TEST_PRESSURE_ALT_VALUE
 
     def test_parse_filtration_schedule_as_attributes(self):
         """Test schedule is exposed as attributes on the filtration status."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -19,6 +19,8 @@ from custom_components.indygo_pool.sensor import (
 TEMP_VALUE = 25.5
 POWER_VALUE = 150.0
 DUR_VALUE = 10
+REDOX_VALUE = 720
+PRESSURE_VALUE = 1.2
 MIN_ENTITIES = 2
 
 
@@ -145,6 +147,39 @@ async def test_async_setup_entry(mock_coordinator):
     keys_added = [e.entity_description.key for e in entities]
     assert "temperature" in keys_added
     assert "totalElectrolyseDuration" in keys_added
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_redox_and_pressure(mock_coordinator):
+    """Test setup entry creates Redox and filter pressure entities."""
+    mock_entry = MagicMock()
+    mock_hass = MagicMock()
+    mock_hass.data = {"indygo_pool": {mock_entry.entry_id: mock_coordinator}}
+
+    mock_coordinator.data.modules = {
+        "mod1": IndygoModuleData(
+            id="mod1",
+            type="lr-pc-vs2",
+            name="Pump",
+            sensors={
+                "redox": IndygoSensorData(key="redox", value=REDOX_VALUE),
+                "filter_pressure": IndygoSensorData(
+                    key="filter_pressure",
+                    value=PRESSURE_VALUE,
+                ),
+            },
+        )
+    }
+
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(mock_hass, mock_entry, async_add_entities)
+
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    keys_added = [e.entity_description.key for e in entities]
+    assert "redox" in keys_added
+    assert "filter_pressure" in keys_added
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Parse Redox (type 7) and filter pressure (types 8/56) from module `inputs`, alongside existing pH, via a shared `_parse_input_sensors` helper applied to all modules (not only IPX).
- Recognize `lr-pc-vs2` and other `lr-pc*` Pool Command variants when resolving hardware IDs and gateway fallback.
- Expose new **Redox** (mV) and **Filter pressure** (bar) sensor entities with EN/FR translations.
- Exclude integration tests from the default pytest run (`-m 'not integration'`).

## Test plan

- [x] `uv run pytest tests` — 103 passed
- [x] `uv run ruff check .` — clean
- [ ] Verify Redox and filter pressure entities appear on a pool with `lr-pc-vs2` hardware
- [ ] Confirm pH sensor still works on IPX modules


Made with [Cursor](https://cursor.com)