### PR TITLE
docs: document v2.4.0 sensors and enable Renovate lock file automerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Indygo Pool is a custom integration for Home Assistant that allows you to monito
 
 - **Temperature Monitoring**: Keep an eye on your pool's water temperature.
 - **pH & Salt levels**: Monitor the chemical balance of your pool.
+- **Redox (ORP)**: Monitor the oxidation-reduction potential of your pool water.
+- **Filter Pressure**: Track filter pressure from Pool Command module inputs.
 - **Electrolyser Status**: Monitor the production status.
 - **Filtration Control**: Switch between Auto, Manual ON, and Manual OFF modes.
+- **Pool Command VS² support**: Compatible with `lr-pc-vs2` hardware variants.
 
 ## Installation
 

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
                 "minor",
                 "patch",
                 "pin",
-                "digest"
+                "digest",
+                "lockFileMaintenance"
             ],
             "automerge": true,
             "automergeType": "branch"


### PR DESCRIPTION
## Summary

- Document v2.4.0 features in README: **Redox (ORP)**, **Filter pressure**, and **Pool Command VS²** support.
- Add `lockFileMaintenance` to Renovate automerge rules so dependency lock refresh PRs can be merged automatically when CI passes.

## Context — CI failure on #155 (lock file maintenance)

The [Validate workflow failure](https://github.com/FunFR/ha-indygo-pool/actions/runs/27870158792/job/82480671578) on the Renovate PR is a **race condition**, not a real HACS issue:

```
Selected version/branch renovate/lock-file-maintenance has been removed, falling back to default
Repository structure for renovate/lock-file-maintenance is not compliant
```

The PR was merged before the HACS check finished; the branch was deleted while the workflow still referenced it. **Main is healthy** — Validate and Test both pass on `main` after merge.

**Risk of the early merge: low.** The change only refreshes `uv.lock`; all 105 tests pass on `main`.

## Context — why Renovate PRs aren't auto-merged

Renovate `automerge: true` was configured for `minor`, `patch`, `pin`, and `digest` only. **`lockFileMaintenance` was excluded**, which is why lock file PRs require manual merge.

Other Renovate PRs (e.g. GitHub Actions, pre-commit) should auto-merge once all status checks pass. Note that GitHub's UI "Enable auto-merge" and Renovate's `automerge` are separate mechanisms — Renovate merges on its own schedule when checks are green, without needing the GitHub auto-merge button.

## Test plan

- [x] `uv run pytest` — 105 passed
- [x] Main CI green after #155 merge


Made with [Cursor](https://cursor.com)