### PR TITLE
feat(switch): control Pool Command auxiliary circuits (spotlight, water blade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Indygo Pool is a custom integration for Home Assistant that allows you to monito
 - **Filter Pressure**: Track filter pressure from Pool Command module inputs.
 - **Electrolyser Status**: Monitor the production status.
 - **Filtration Control**: Switch between Auto, Manual ON, and Manual OFF modes.
+- **Auxiliary circuits**: Control the devices wired to the Pool Command auxiliary outputs — spotlight, water blade, secondary pump — as switches, reporting the live circuit state published by the board.
 - **Pool Command VS² support**: Compatible with `lr-pc-vs2` hardware variants.
 
 ## Installation

--- a/custom_components/indygo_pool/__init__.py
+++ b/custom_components/indygo_pool/__init__.py
@@ -17,6 +17,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SELECT,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import aiohttp
 
-from .const import LOGGER, PROGRAM_TYPE_FILTRATION
+from .const import LOGGER
 from .models import IndygoPoolData
 from .parser import IndygoParser
 
@@ -347,16 +347,38 @@ class IndygoPoolApiClient:
         return self._data
 
     # ------------------------------------------------------------------
-    # Filtration mode control
+    # Program mode control
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_target_program(program: dict, target: dict) -> bool:
+        """Return True when ``program`` is the one being updated.
+
+        Matches on the program ``id`` when available, and falls back to the
+        program ``index`` — some payloads carry no identifier.
+        """
+        target_id = target.get("id")
+        if target_id is not None:
+            return program.get("id") == target_id
+
+        target_index = target.get("index")
+        return target_index is not None and program.get("index") == target_index
 
     async def async_set_filtration_mode(
         self, module_id: str, full_program_data: dict, mode: int
     ) -> None:
-        """Set the filtration mode (Auto/Off/On) safely.
+        """Set the filtration mode (Auto/Off/On) safely."""
+        await self.async_set_program_mode(module_id, full_program_data, mode)
 
-        Sends the FULL program list back (like the Android app) to avoid
-        corrupting the device configuration.
+    async def async_set_program_mode(
+        self, module_id: str, full_program_data: dict, mode: int
+    ) -> None:
+        """Set the mode (Off/On/Auto) of a single module program.
+
+        Sends the FULL program list back (like the vendor apps) to avoid
+        corrupting the device configuration.  Only the targeted program has
+        its mode changed: every other program is sent back carrying its own
+        current mode, which is what the vendor apps do.
         """
         program_copy = copy.deepcopy(full_program_data)
 
@@ -372,34 +394,25 @@ class IndygoPoolApiClient:
         if self._data and module_id in self._data.modules:
             module_programs = self._data.modules[module_id].programs
 
-        # Build the full programs list with updated filtration program
+        # Build the full programs list with the updated target program
         updated_programs = []
-        program_id = program_copy.get("id")
         program_found = False
         for prog in module_programs:
-            if prog.get("id") == program_id:
+            if self._is_target_program(prog, program_copy):
                 updated_programs.append(program_copy)
                 program_found = True
             else:
                 prog_copy = copy.deepcopy(prog)
                 prog_copy["dataChanged"] = True
-                prog_type = prog_copy.get("programCharacteristics", {}).get(
-                    "programType"
-                )
-                if prog_type != PROGRAM_TYPE_FILTRATION:
-                    if (
-                        "programCharacteristics" in prog_copy
-                        and "mode" in prog_copy["programCharacteristics"]
-                    ):
-                        prog_copy["programCharacteristics"]["mode"] = None
                 updated_programs.append(prog_copy)
 
         if not program_found:
             updated_programs.append(program_copy)
 
         LOGGER.debug(
-            "Setting filtration mode to %s for module %s. Sending %d programs.",
+            "Setting mode %s on program %s of module %s. Sending %d programs.",
             mode,
+            program_copy.get("id") or program_copy.get("index"),
             module_id,
             len(updated_programs),
         )
@@ -436,7 +449,7 @@ class IndygoPoolApiClient:
                 )
 
         except IndygoPoolApiClientError as exc:
-            LOGGER.error("Failed to set filtration mode: %s", exc)
+            LOGGER.error("Failed to set program mode: %s", exc)
             raise
 
     # ------------------------------------------------------------------

--- a/custom_components/indygo_pool/const.py
+++ b/custom_components/indygo_pool/const.py
@@ -17,3 +17,12 @@ CONF_PASSWORD = "password"
 CONF_POOL_ID = "pool_id"
 
 PROGRAM_TYPE_FILTRATION = 4
+# Spotlight / pool light program. Confirmed on LR-PC hardware: the vendor apps
+# write programCharacteristics.mode on this program to switch the light on (1)
+# and off (0). Such programs also carry metadata.spotlightType.
+PROGRAM_TYPE_LIGHTING = 2
+
+# programCharacteristics.mode values.
+PROGRAM_MODE_OFF = 0
+PROGRAM_MODE_ON = 1
+PROGRAM_MODE_AUTO = 2

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -259,7 +259,13 @@ class IndygoParser:
         pool_data: IndygoPoolData,
         filt_module: IndygoModuleData | None = None,
     ) -> None:
-        """Parse 'pool' list which contains status for Filtration, etc."""
+        """Parse the 'pool' list: live state of every board circuit.
+
+        Index 0 is the filtration circuit.  The following indexes are the
+        auxiliary outputs of the Pool Command (spotlight, water blade, ...)
+        and map one-to-one onto the module programs and outputs carrying the
+        same index.
+        """
         if "pool" not in json_data or not isinstance(json_data["pool"], list):
             return
         target_status = (
@@ -268,18 +274,21 @@ class IndygoParser:
 
         for item in json_data["pool"]:
             idx = item.get("index")
+            if idx is None:
+                continue
+
             val = item.get("value")
+            temp_ref = item.get("tempRef")
+            remaining_time = item.get("time")
+
+            extra_attributes = {
+                "info": item.get("info"),
+                "time": remaining_time,
+                "tempRef": temp_ref,
+            }
 
             if idx == 0:
-                temp_ref = item.get("tempRef")
-                remaining_time = item.get("time")
-
-                extra_attributes = {
-                    "info": item.get("info"),
-                    "time": remaining_time,
-                    "tempRef": temp_ref,
-                }
-
+                key = "filtration_status"
                 if filt_module:
                     dialog_ts = self._parse_dialog_timestamp(
                         json_data.get("dialogTimeStamp")
@@ -289,22 +298,22 @@ class IndygoParser:
                             filt_module, temp_ref, dialog_ts
                         )
                     )
+            else:
+                key = f"circuit_{idx}_status"
 
-                target_status["0"] = IndygoSensorData(
-                    key="filtration_status",
-                    value=val,
-                    extra_attributes=extra_attributes,
-                )
+            target_status[str(idx)] = IndygoSensorData(
+                key=key,
+                value=val,
+                extra_attributes=extra_attributes,
+            )
 
-                if remaining_time and filt_module:
-                    remaining_minutes = self._parse_remaining_time(remaining_time)
-                    if remaining_minutes is not None:
-                        filt_module.sensors["filtration_remaining_time"] = (
-                            IndygoSensorData(
-                                key="filtration_remaining_time",
-                                value=remaining_minutes,
-                            )
-                        )
+            if idx == 0 and remaining_time and filt_module:
+                remaining_minutes = self._parse_remaining_time(remaining_time)
+                if remaining_minutes is not None:
+                    filt_module.sensors["filtration_remaining_time"] = IndygoSensorData(
+                        key="filtration_remaining_time",
+                        value=remaining_minutes,
+                    )
 
     def _parse_root_sensors(
         self,

--- a/custom_components/indygo_pool/strings.json
+++ b/custom_components/indygo_pool/strings.json
@@ -92,6 +92,14 @@
             "filtration_mode": {
                 "name": "Filtration mode"
             }
+        },
+        "switch": {
+            "spotlight": {
+                "name": "Spotlight"
+            },
+            "auxiliary_circuit": {
+                "name": "{circuit}"
+            }
         }
     }
 }

--- a/custom_components/indygo_pool/switch.py
+++ b/custom_components/indygo_pool/switch.py
@@ -1,0 +1,260 @@
+"""Switch platform for Indygo Pool.
+
+Exposes the auxiliary circuits of a Pool Command board (spotlight, water
+blade, secondary pump, ...) as switches.  Turning a switch on or off writes
+``programCharacteristics.mode`` on the matching program, which is exactly what
+the vendor apps do; the reported state comes from the live circuit state
+published by the board.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+
+from .const import (
+    DOMAIN,
+    LOGGER,
+    PROGRAM_MODE_AUTO,
+    PROGRAM_MODE_OFF,
+    PROGRAM_MODE_ON,
+    PROGRAM_TYPE_FILTRATION,
+    PROGRAM_TYPE_LIGHTING,
+)
+from .coordinator import IndygoPoolDataUpdateCoordinator
+from .entity import IndygoPoolEntity
+from .models import IndygoModuleData
+
+# Delay (seconds) before a follow-up refresh after a mode change.  The command
+# travels cloud → gateway → LoRa → device and the device then reports back, so
+# the status endpoint keeps returning the old state for a short while.
+DELAYED_REFRESH_SECONDS = 30
+
+# Human-readable mode, exposed as an attribute so automations can tell an
+# explicit On/Off from a scheduled Auto.
+PROGRAM_MODE_NAMES = {
+    PROGRAM_MODE_OFF: "off",
+    PROGRAM_MODE_ON: "on",
+    PROGRAM_MODE_AUTO: "auto",
+}
+
+
+def _program_index(program: dict) -> int | None:
+    """Return the circuit index of a program, when it has one."""
+    index = program.get("index")
+    return index if isinstance(index, int) else None
+
+
+def _output_name(module: IndygoModuleData, index: int) -> str | None:
+    """Return the board output name matching a circuit index."""
+    outputs = module.raw_data.get("outputs")
+    if not isinstance(outputs, list):
+        return None
+    for output in outputs:
+        if isinstance(output, dict) and output.get("index") == index:
+            name = output.get("name")
+            if isinstance(name, str) and name:
+                return name
+    return None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the switch platform."""
+    coordinator: IndygoPoolDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[IndygoPoolCircuitSwitch] = []
+
+    if not coordinator.data:
+        return
+
+    for module_id, module in coordinator.data.modules.items():
+        used_suffixes: set[str] = set()
+
+        for program in module.programs:
+            characteristics = program.get("programCharacteristics")
+            if not isinstance(characteristics, dict):
+                continue
+
+            program_type = characteristics.get("programType")
+            if program_type == PROGRAM_TYPE_FILTRATION:
+                # Filtration already has its own three-state select entity.
+                continue
+
+            index = _program_index(program)
+            if index is None:
+                continue
+
+            # Known program types get a dedicated name; anything else falls
+            # back to the board output label, so unmapped hardware still shows
+            # up instead of being silently dropped.
+            if program_type == PROGRAM_TYPE_LIGHTING and "spotlight" not in (
+                used_suffixes
+            ):
+                translation_key = "spotlight"
+                suffix = "spotlight"
+                placeholders = None
+            else:
+                translation_key = "auxiliary_circuit"
+                suffix = f"circuit_{index}"
+                placeholders = {
+                    "circuit": _output_name(module, index) or str(index + 1)
+                }
+
+            used_suffixes.add(suffix)
+            entities.append(
+                IndygoPoolCircuitSwitch(
+                    coordinator=coordinator,
+                    module_id=module_id,
+                    circuit_index=index,
+                    translation_key=translation_key,
+                    entity_suffix=suffix,
+                    translation_placeholders=placeholders,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
+    """A single auxiliary circuit of a Pool Command board."""
+
+    def __init__(
+        self,
+        coordinator: IndygoPoolDataUpdateCoordinator,
+        module_id: str,
+        circuit_index: int,
+        translation_key: str,
+        entity_suffix: str,
+        translation_placeholders: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, module_id)
+        self._circuit_index = circuit_index
+        self._attr_translation_key = translation_key
+        if translation_placeholders:
+            self._attr_translation_placeholders = translation_placeholders
+        self._attr_unique_id = self._build_unique_id(f"circuit_{circuit_index}")
+        self.entity_id = f"switch.{self.device_name_slug}_{entity_suffix}"
+        self._cancel_delayed_refresh: CALLBACK_TYPE | None = None
+
+    # ------------------------------------------------------------------
+    # Data helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _module(self) -> IndygoModuleData | None:
+        """Return the owning module, if still present in the coordinator."""
+        data = self.coordinator.data
+        if not data or self._module_id not in data.modules:
+            return None
+        return data.modules[self._module_id]
+
+    @property
+    def _program(self) -> dict | None:
+        """Return the program driving this circuit."""
+        module = self._module
+        if not module:
+            return None
+        for program in module.programs:
+            if _program_index(program) == self._circuit_index:
+                return program
+        return None
+
+    @property
+    def _mode(self) -> int | None:
+        """Return the programmed mode of this circuit."""
+        program = self._program
+        if not program:
+            return None
+        mode = program.get("programCharacteristics", {}).get("mode")
+        return mode if isinstance(mode, int) else None
+
+    @property
+    def _circuit_state(self) -> bool | None:
+        """Return the live circuit state reported by the board."""
+        module = self._module
+        if not module:
+            return None
+        status = module.pool_status.get(str(self._circuit_index))
+        if status is None or status.value is None:
+            return None
+        try:
+            return float(status.value) == 1.0
+        except (ValueError, TypeError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Entity
+    # ------------------------------------------------------------------
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the circuit is powered."""
+        state = self._circuit_state
+        if state is not None:
+            return state
+        # Hardware that does not answer the live status endpoint leaves us
+        # with the programmed mode only.
+        return self._mode == PROGRAM_MODE_ON
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        mode = self._mode
+        return {
+            "circuit_index": self._circuit_index,
+            "program_mode": PROGRAM_MODE_NAMES.get(mode, mode),
+            "state_source": (
+                "circuit" if self._circuit_state is not None else "program_mode"
+            ),
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the circuit on."""
+        await self._async_set_mode(PROGRAM_MODE_ON)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the circuit off."""
+        await self._async_set_mode(PROGRAM_MODE_OFF)
+
+    async def _async_set_mode(self, mode: int) -> None:
+        """Write a new mode on the program driving this circuit."""
+        program = self._program
+        if not program:
+            LOGGER.error(
+                "Cannot set mode: no program for circuit %s of module %s",
+                self._circuit_index,
+                self._module_id,
+            )
+            return
+
+        await self.coordinator.client.async_set_program_mode(
+            self._module_id, program, mode
+        )
+
+        await self.coordinator.async_request_refresh()
+        self._schedule_delayed_refresh()
+
+    def _schedule_delayed_refresh(self) -> None:
+        """Schedule a coordinator refresh after a delay."""
+        if self._cancel_delayed_refresh:
+            self._cancel_delayed_refresh()
+
+        self._cancel_delayed_refresh = async_call_later(
+            self.hass,
+            DELAYED_REFRESH_SECONDS,
+            self._async_delayed_refresh,
+        )
+
+    async def _async_delayed_refresh(self, _now: object) -> None:
+        """Perform the delayed coordinator refresh."""
+        self._cancel_delayed_refresh = None
+        await self.coordinator.async_request_refresh()

--- a/custom_components/indygo_pool/switch.py
+++ b/custom_components/indygo_pool/switch.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
@@ -202,8 +202,13 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
         if state is not None:
             return state
         # Hardware that does not answer the live status endpoint leaves us
-        # with the programmed mode only.
-        return self._mode == PROGRAM_MODE_ON
+        # with the programmed mode only.  When that is missing too — the
+        # module dropped out of the payload — the honest answer is "unknown",
+        # not "off".
+        mode = self._mode
+        if mode is None:
+            return None
+        return mode == PROGRAM_MODE_ON
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -243,6 +248,7 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
         self._schedule_delayed_refresh()
 
+    @callback
     def _schedule_delayed_refresh(self) -> None:
         """Schedule a coordinator refresh after a delay."""
         if self._cancel_delayed_refresh:
@@ -251,10 +257,26 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
         self._cancel_delayed_refresh = async_call_later(
             self.hass,
             DELAYED_REFRESH_SECONDS,
-            self._async_delayed_refresh,
+            self._delayed_refresh_callback,
         )
 
-    async def _async_delayed_refresh(self, _now: object) -> None:
-        """Perform the delayed coordinator refresh."""
+    @callback
+    def _delayed_refresh_callback(self, _now: object) -> None:
+        """Fire the delayed coordinator refresh.
+
+        Invoked by ``async_call_later`` in the event loop, so it stays
+        synchronous and hands the awaitable work to a task.
+        """
         self._cancel_delayed_refresh = None
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self.coordinator.async_request_refresh())
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel a pending delayed refresh when the entity goes away.
+
+        Without this, unloading or reloading the integration during the
+        30 s window leaves the timer armed and it fires on a dead entity.
+        """
+        if self._cancel_delayed_refresh:
+            self._cancel_delayed_refresh()
+            self._cancel_delayed_refresh = None
+        await super().async_will_remove_from_hass()

--- a/custom_components/indygo_pool/translations/en.json
+++ b/custom_components/indygo_pool/translations/en.json
@@ -94,6 +94,14 @@
             "filtration_mode": {
                 "name": "Filtration mode"
             }
+        },
+        "switch": {
+            "spotlight": {
+                "name": "Spotlight"
+            },
+            "auxiliary_circuit": {
+                "name": "{circuit}"
+            }
         }
     }
 }

--- a/custom_components/indygo_pool/translations/fr.json
+++ b/custom_components/indygo_pool/translations/fr.json
@@ -94,6 +94,14 @@
             "filtration_mode": {
                 "name": "Mode filtration"
             }
+        },
+        "switch": {
+            "spotlight": {
+                "name": "Projecteur"
+            },
+            "auxiliary_circuit": {
+                "name": "{circuit}"
+            }
         }
     }
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -515,10 +515,18 @@ OTHER_PROGRAM = {
     "programCharacteristics": {"mode": 1, "programType": 1},
 }
 
+PROGRAM_MODE_AUTO = 2
+EXPECTED_PROGRAM_COUNT = 2
+
 
 @pytest.mark.asyncio
-async def test_set_filtration_mode_clears_mode_on_non_filtration():
-    """Test that non-filtration programs have their mode cleared."""
+async def test_set_filtration_mode_preserves_other_program_modes():
+    """Non-target programs keep their own mode.
+
+    The vendor apps send the whole program list back with every program
+    carrying its real mode; clearing the siblings would push a null mode
+    onto the spotlight and auxiliary circuits of the board.
+    """
     if aioresponses is None:
         pytest.skip("aioresponses not installed")
 
@@ -542,12 +550,89 @@ async def test_set_filtration_mode_clears_mode_on_non_filtration():
                 TEST_MODULE_ID, FILT_PROGRAM_WITH_ID, 2
             )
 
-            # Verify other program had mode cleared
             req = m.requests[("PUT", URL(f"{BASE_URL}/api/updatePrograms"))][0]
             payload = req.kwargs.get("json", {})
+
+            target = payload["programs"][0]
+            assert target["programCharacteristics"]["mode"] == PROGRAM_MODE_AUTO
+
             other = payload["programs"][1]
-            assert other["programCharacteristics"]["mode"] is None
+            assert other["programCharacteristics"]["mode"] == 1
             assert other["dataChanged"] is True
+
+            # The caller's dict must not be mutated in place.
+            assert OTHER_PROGRAM["programCharacteristics"]["mode"] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_program_mode_targets_only_requested_program():
+    """Setting an auxiliary program leaves filtration untouched."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    with aioresponses() as m:
+        _mock_filtration_endpoints(m)
+
+        async with aiohttp.ClientSession() as session:
+            client = _make_client(session)
+            client._pool_address = TEST_POOL_ADDRESS
+            client._device_short_id = "ABC"
+            client._data = IndygoPoolData(pool_id=TEST_POOL_ID)
+            client._data.modules[TEST_MODULE_ID] = IndygoModuleData(
+                id=TEST_MODULE_ID,
+                type="lr-pc",
+                name="Pump",
+                programs=[FILT_PROGRAM_WITH_ID, OTHER_PROGRAM],
+                raw_data={"serialNumber": TEST_SERIAL},
+            )
+
+            await client.async_set_program_mode(TEST_MODULE_ID, OTHER_PROGRAM, 0)
+
+            req = m.requests[("PUT", URL(f"{BASE_URL}/api/updatePrograms"))][0]
+            payload = req.kwargs.get("json", {})
+
+            assert payload["programs"][0]["programCharacteristics"]["mode"] == 0
+            assert payload["programs"][1]["programCharacteristics"]["mode"] == 0
+            assert payload["programs"][0]["id"] == "prog_1"
+            assert payload["programs"][1]["id"] == "prog_2"
+
+
+@pytest.mark.asyncio
+async def test_set_program_mode_matches_on_index_without_id():
+    """Programs without an id are matched on their index."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    filtration = {"index": 0, "programCharacteristics": {"mode": 2, "programType": 4}}
+    spotlight = {"index": 1, "programCharacteristics": {"mode": 0, "programType": 2}}
+
+    with aioresponses() as m:
+        _mock_filtration_endpoints(m)
+
+        async with aiohttp.ClientSession() as session:
+            client = _make_client(session)
+            client._pool_address = TEST_POOL_ADDRESS
+            client._device_short_id = "ABC"
+            client._data = IndygoPoolData(pool_id=TEST_POOL_ID)
+            client._data.modules[TEST_MODULE_ID] = IndygoModuleData(
+                id=TEST_MODULE_ID,
+                type="lr-pc",
+                name="Pump",
+                programs=[filtration, spotlight],
+                raw_data={"serialNumber": TEST_SERIAL},
+            )
+
+            await client.async_set_program_mode(TEST_MODULE_ID, spotlight, 1)
+
+            req = m.requests[("PUT", URL(f"{BASE_URL}/api/updatePrograms"))][0]
+            payload = req.kwargs.get("json", {})
+
+            assert len(payload["programs"]) == EXPECTED_PROGRAM_COUNT
+            assert (
+                payload["programs"][0]["programCharacteristics"]["mode"]
+                == PROGRAM_MODE_AUTO
+            )
+            assert payload["programs"][1]["programCharacteristics"]["mode"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -787,3 +787,90 @@ class TestGetNested:
     def test_returns_none_on_invalid_index(self):
         """Test with non-numeric key on a list."""
         assert _get_nested([1, 2], "abc") is None
+
+
+class TestPoolCircuits:
+    """Test parsing of the 'pool' list beyond the filtration circuit."""
+
+    @staticmethod
+    def _json(pool: list[dict]) -> dict:
+        return {
+            "modules": [
+                {
+                    "id": "MOD1",
+                    "type": "lr-pc",
+                    "name": "LRPC-D37902",
+                    "programs": [
+                        {
+                            "index": 0,
+                            "programCharacteristics": {
+                                "programType": FILTRATION_PROGRAM_TYPE,
+                                "mode": MODE_ON,
+                            },
+                        }
+                    ],
+                }
+            ],
+            "pool": pool,
+        }
+
+    def test_parses_every_circuit(self):
+        """Auxiliary circuits are exposed alongside the filtration one."""
+        parser = IndygoParser()
+        pool_data = parser.parse_data(
+            self._json(
+                [
+                    {"index": 0, "value": 1},
+                    {"index": 1, "value": 1, "info": []},
+                    {"index": 2, "value": 0},
+                ]
+            ),
+            "P1",
+            "A1",
+            "R1",
+        )
+
+        status = pool_data.modules["MOD1"].pool_status
+        assert set(status) == {"0", "1", "2"}
+        assert status["0"].key == "filtration_status"
+        assert status["1"].key == "circuit_1_status"
+        assert status["1"].value == 1
+        assert status["2"].value == 0
+
+    def test_auxiliary_circuits_carry_their_attributes(self):
+        """Auxiliary circuits keep the raw payload fields as attributes."""
+        parser = IndygoParser()
+        pool_data = parser.parse_data(
+            self._json([{"index": 1, "value": 1, "info": [], "time": "00:00"}]),
+            "P1",
+            "A1",
+            "R1",
+        )
+
+        attrs = pool_data.modules["MOD1"].pool_status["1"].extra_attributes
+        assert attrs["info"] == []
+        assert attrs["time"] == "00:00"
+
+    def test_remaining_time_stays_filtration_only(self):
+        """The remaining-time sensor is not created for auxiliary circuits."""
+        parser = IndygoParser()
+        pool_data = parser.parse_data(
+            self._json([{"index": 1, "value": 1, "time": "01:30"}]),
+            "P1",
+            "A1",
+            "R1",
+        )
+
+        assert "filtration_remaining_time" not in pool_data.modules["MOD1"].sensors
+
+    def test_skips_entries_without_index(self):
+        """A malformed entry is ignored rather than stored under 'None'."""
+        parser = IndygoParser()
+        pool_data = parser.parse_data(
+            self._json([{"value": 1}, {"index": 1, "value": 1}]),
+            "P1",
+            "A1",
+            "R1",
+        )
+
+        assert set(pool_data.modules["MOD1"].pool_status) == {"1"}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -243,11 +243,15 @@ class TestState:
         assert attributes["circuit_index"] == 1
 
     def test_unknown_module(self, mock_coordinator):
-        """A module that disappeared yields no state and no crash."""
+        """A module that disappeared yields unknown, not off.
+
+        Reporting False here would state that the circuit is powered down,
+        which we have no way of knowing once the module left the payload.
+        """
         mock_coordinator.data.modules = {}
         entity = _switch(mock_coordinator)
 
-        assert entity.is_on is False
+        assert entity.is_on is None
         assert entity.extra_state_attributes["program_mode"] is None
 
 
@@ -312,20 +316,57 @@ class TestCommands:
 
     @pytest.mark.asyncio
     async def test_delayed_refresh_callback(self, mock_coordinator):
-        """The delayed callback refreshes and clears its handle."""
+        """The timer target must work the way HA invokes it: a plain call.
+
+        The previous version of this test awaited the target, which only
+        proved that a coroutine can be awaited — not that the scheduler's
+        synchronous call works.  Here it is called exactly as
+        ``async_call_later`` calls it.
+        """
         mock_coordinator.data.modules = {"mod1": _module()}
         entity = _switch(mock_coordinator)
+        entity.hass = MagicMock()
 
         with patch(
             "custom_components.indygo_pool.switch.async_call_later"
         ) as mock_call_later:
             await entity.async_turn_on()
 
-        callback = mock_call_later.call_args[0][2]
-        mock_coordinator.async_request_refresh.reset_mock()
-        await callback(None)
+        timer_target = mock_call_later.call_args[0][2]
+        assert timer_target(None) is None
 
-        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert entity._cancel_delayed_refresh is None
+        entity.hass.async_create_task.assert_called_once()
+        # Close the coroutine handed to the task so it is not left un-awaited.
+        entity.hass.async_create_task.call_args[0][0].close()
+
+    @pytest.mark.asyncio
+    async def test_removal_cancels_pending_refresh(self, mock_coordinator):
+        """Unloading during the delay window disarms the timer."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+        entity.hass = MagicMock()
+
+        cancel_cb = MagicMock()
+        with patch(
+            "custom_components.indygo_pool.switch.async_call_later",
+            return_value=cancel_cb,
+        ):
+            await entity.async_turn_on()
+
+        await entity.async_will_remove_from_hass()
+
+        cancel_cb.assert_called_once()
+        assert entity._cancel_delayed_refresh is None
+
+    @pytest.mark.asyncio
+    async def test_removal_without_pending_refresh_is_a_no_op(self, mock_coordinator):
+        """Removing an idle entity must not raise."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+
+        await entity.async_will_remove_from_hass()
+
         assert entity._cancel_delayed_refresh is None
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,337 @@
+"""Tests for the Indygo Pool switch entities (Pool Command circuits)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.indygo_pool.models import (
+    IndygoModuleData,
+    IndygoPoolData,
+    IndygoSensorData,
+)
+from custom_components.indygo_pool.switch import (
+    IndygoPoolCircuitSwitch,
+    async_setup_entry,
+)
+
+FILTRATION_PROGRAM = {
+    "id": "prog_0",
+    "index": 0,
+    "programCharacteristics": {"mode": 1, "programType": 4},
+}
+SPOTLIGHT_PROGRAM = {
+    "id": "prog_1",
+    "index": 1,
+    "programCharacteristics": {"mode": 0, "programType": 2},
+}
+AUXILIARY_PROGRAM = {
+    "id": "prog_2",
+    "index": 2,
+    "programCharacteristics": {"mode": 0, "programType": 5},
+}
+
+EXPECTED_SWITCH_COUNT = 2
+
+OUTPUTS = [
+    {"index": 0, "name": "Station 1"},
+    {"index": 1, "name": "Station 2"},
+    {"index": 2, "name": "Station 3"},
+]
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Mock the coordinator."""
+    coordinator = MagicMock(spec=DataUpdateCoordinator)
+    coordinator.data = MagicMock(spec=IndygoPoolData)
+    coordinator.data.modules = {}
+    coordinator.data.pool_id = "test_pool_id"
+    coordinator.client = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.entry_id = "test_entry_id"
+    return coordinator
+
+
+def _module(pool_status: dict | None = None) -> IndygoModuleData:
+    """Build a Pool Command module with three circuits."""
+    return IndygoModuleData(
+        id="mod1",
+        type="lr-pc",
+        name="LRPC-D37902",
+        programs=[FILTRATION_PROGRAM, SPOTLIGHT_PROGRAM, AUXILIARY_PROGRAM],
+        raw_data={"outputs": OUTPUTS},
+        pool_status=pool_status or {},
+    )
+
+
+def _switch(coordinator, index: int = 1) -> IndygoPoolCircuitSwitch:
+    """Build a switch for a given circuit index."""
+    return IndygoPoolCircuitSwitch(
+        coordinator=coordinator,
+        module_id="mod1",
+        circuit_index=index,
+        translation_key="spotlight",
+        entity_suffix="spotlight",
+    )
+
+
+class TestSetup:
+    """Test the platform setup."""
+
+    async def _run_setup(self, coordinator):
+        hass = MagicMock(spec=HomeAssistant)
+        entry = MagicMock(spec=ConfigEntry)
+        entry.entry_id = "test_entry_id"
+        hass.data = {"indygo_pool": {"test_entry_id": coordinator}}
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(hass, entry, async_add_entities)
+        return async_add_entities
+
+    @pytest.mark.asyncio
+    async def test_creates_one_switch_per_non_filtration_program(
+        self, mock_coordinator
+    ):
+        """Filtration keeps its select; every other circuit gets a switch."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+
+        async_add_entities = await self._run_setup(mock_coordinator)
+
+        entities = async_add_entities.call_args[0][0]
+        assert len(entities) == EXPECTED_SWITCH_COUNT
+        assert [e._circuit_index for e in entities] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_names_lighting_and_falls_back_for_unknown_types(
+        self, mock_coordinator
+    ):
+        """An unmapped program type still yields an entity, named after its output."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+
+        async_add_entities = await self._run_setup(mock_coordinator)
+        spotlight, auxiliary = async_add_entities.call_args[0][0]
+
+        assert spotlight._attr_translation_key == "spotlight"
+        assert spotlight.entity_id == "switch.lrpc_d37902_spotlight"
+
+        assert auxiliary._attr_translation_key == "auxiliary_circuit"
+        assert auxiliary._attr_translation_placeholders == {"circuit": "Station 3"}
+        assert auxiliary.entity_id == "switch.lrpc_d37902_circuit_2"
+
+    @pytest.mark.asyncio
+    async def test_placeholder_falls_back_to_index_without_output_name(
+        self, mock_coordinator
+    ):
+        """Missing output labels fall back to a 1-based circuit number."""
+        module = _module()
+        module.raw_data = {}
+        mock_coordinator.data.modules = {"mod1": module}
+
+        async_add_entities = await self._run_setup(mock_coordinator)
+        _, auxiliary = async_add_entities.call_args[0][0]
+
+        assert auxiliary._attr_translation_placeholders == {"circuit": "3"}
+
+    @pytest.mark.asyncio
+    async def test_placeholder_ignores_blank_output_name(self, mock_coordinator):
+        """An output with an empty label also falls back to the index."""
+        module = _module()
+        module.raw_data = {"outputs": [{"index": 2, "name": ""}]}
+        mock_coordinator.data.modules = {"mod1": module}
+
+        async_add_entities = await self._run_setup(mock_coordinator)
+        _, auxiliary = async_add_entities.call_args[0][0]
+
+        assert auxiliary._attr_translation_placeholders == {"circuit": "3"}
+
+    @pytest.mark.asyncio
+    async def test_skips_programs_without_index_or_characteristics(
+        self, mock_coordinator
+    ):
+        """Malformed programs are ignored rather than crashing setup."""
+        module = _module()
+        module.programs = [
+            {"id": "a", "index": 1},
+            {"id": "b", "programCharacteristics": {"programType": 2}},
+        ]
+        mock_coordinator.data.modules = {"mod1": module}
+
+        async_add_entities = await self._run_setup(mock_coordinator)
+
+        assert async_add_entities.call_args[0][0] == []
+
+    @pytest.mark.asyncio
+    async def test_no_data(self, mock_coordinator):
+        """No coordinator data means no entities."""
+        mock_coordinator.data = None
+        async_add_entities = await self._run_setup(mock_coordinator)
+
+        async_add_entities.assert_not_called()
+
+
+class TestState:
+    """Test how the switch reports its state."""
+
+    def test_is_on_from_live_circuit_state(self, mock_coordinator):
+        """The live circuit value drives the state."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=1)})
+        }
+        entity = _switch(mock_coordinator)
+
+        assert entity.is_on is True
+        assert entity.extra_state_attributes["state_source"] == "circuit"
+
+    def test_is_on_false_when_circuit_off(self, mock_coordinator):
+        """A circuit reported at 0 is off, whatever the programmed mode."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=0)})
+        }
+        entity = _switch(mock_coordinator)
+
+        assert entity.is_on is False
+
+    def test_falls_back_to_program_mode(self, mock_coordinator):
+        """Hardware without live status falls back to the programmed mode."""
+        module = _module()
+        module.programs = [
+            FILTRATION_PROGRAM,
+            {
+                "id": "prog_1",
+                "index": 1,
+                "programCharacteristics": {"mode": 1, "programType": 2},
+            },
+        ]
+        mock_coordinator.data.modules = {"mod1": module}
+        entity = _switch(mock_coordinator)
+
+        assert entity.is_on is True
+        assert entity.extra_state_attributes["state_source"] == "program_mode"
+
+    def test_non_numeric_circuit_value_falls_back(self, mock_coordinator):
+        """An unparsable circuit value must not raise."""
+        mock_coordinator.data.modules = {
+            "mod1": _module(
+                {"1": IndygoSensorData(key="circuit_1_status", value="oops")}
+            )
+        }
+        entity = _switch(mock_coordinator)
+
+        assert entity.is_on is False
+        assert entity.extra_state_attributes["state_source"] == "program_mode"
+
+    def test_attributes_expose_the_programmed_mode(self, mock_coordinator):
+        """The tri-state mode stays visible even behind a two-state switch."""
+        module = _module({"1": IndygoSensorData(key="circuit_1_status", value=1)})
+        module.programs = [
+            FILTRATION_PROGRAM,
+            {
+                "id": "prog_1",
+                "index": 1,
+                "programCharacteristics": {"mode": 2, "programType": 2},
+            },
+        ]
+        mock_coordinator.data.modules = {"mod1": module}
+        entity = _switch(mock_coordinator)
+
+        attributes = entity.extra_state_attributes
+        assert attributes["program_mode"] == "auto"
+        assert attributes["circuit_index"] == 1
+
+    def test_unknown_module(self, mock_coordinator):
+        """A module that disappeared yields no state and no crash."""
+        mock_coordinator.data.modules = {}
+        entity = _switch(mock_coordinator)
+
+        assert entity.is_on is False
+        assert entity.extra_state_attributes["program_mode"] is None
+
+
+class TestCommands:
+    """Test the write path."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_writes_mode_one(self, mock_coordinator):
+        """Turning on writes mode 1 on the matching program."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_on()
+
+        mock_coordinator.client.async_set_program_mode.assert_awaited_once_with(
+            "mod1", SPOTLIGHT_PROGRAM, 1
+        )
+        mock_coordinator.async_request_refresh.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_writes_mode_zero(self, mock_coordinator):
+        """Turning off writes a hard 0, like the vendor apps do."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_off()
+
+        mock_coordinator.client.async_set_program_mode.assert_awaited_once_with(
+            "mod1", SPOTLIGHT_PROGRAM, 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_program_does_not_call_the_api(self, mock_coordinator):
+        """A circuit without a program cannot be commanded."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator, index=7)
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_on()
+
+        mock_coordinator.client.async_set_program_mode.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delayed_refresh_is_rescheduled(self, mock_coordinator):
+        """A second command cancels the pending delayed refresh."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+        entity.hass = MagicMock()
+
+        cancel_cb = MagicMock()
+        with patch(
+            "custom_components.indygo_pool.switch.async_call_later",
+            return_value=cancel_cb,
+        ):
+            await entity.async_turn_on()
+            cancel_cb.assert_not_called()
+
+            await entity.async_turn_off()
+            cancel_cb.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delayed_refresh_callback(self, mock_coordinator):
+        """The delayed callback refreshes and clears its handle."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
+
+        with patch(
+            "custom_components.indygo_pool.switch.async_call_later"
+        ) as mock_call_later:
+            await entity.async_turn_on()
+
+        callback = mock_call_later.call_args[0][2]
+        mock_coordinator.async_request_refresh.reset_mock()
+        await callback(None)
+
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert entity._cancel_delayed_refresh is None
+
+
+def test_unique_id_is_stable_per_circuit(mock_coordinator):
+    """Unique IDs are built from the pool, module and circuit index."""
+    mock_coordinator.data.modules = {"mod1": _module()}
+    entity = _switch(mock_coordinator, index=2)
+
+    assert entity.unique_id == "test_pool_id_mod1_circuit_2"


### PR DESCRIPTION
Closes #123 (light control part), closes #151.

Exposes the devices wired to the Pool Command auxiliary outputs — spotlight, water blade, secondary pump — as switch entities, with their live on/off state.

## Credit

The groundwork for this is [@la-bagu3tte's technical write-up in #151](https://github.com/FunFR/ha-indygo-pool/issues/151#issuecomment-4798506666). Identifying programs by `programType` rather than by user-editable name, generalising `async_set_filtration_mode`, and spotting the sibling-mode issue are all their analysis — thank you. This PR builds directly on it, with two changes: entities are derived generically instead of from a fixed program-type table, and the state comes from the board rather than from the programmed mode. Details below.

## What the hardware does

Verified on an `lr-pc` board (LRPC-D37902, firmware 7.0.9) by watching the cloud payload while driving the light from the vendor apps:

| Question | Answer | How it was established |
|---|---|---|
| Which program drives the light | `programType: 2` (also carries `metadata.spotlightType`) | it is the program the vendor app rewrites when the light is toggled |
| Turning on | `programCharacteristics.mode = 1` | observed `0 → 1` on switch-on |
| Turning off | `mode = 0` — a hard off, **not** a return to Auto | observed `1 → 0` on switch-off |
| Live state | `pool[index].value`, indexes matching programs and outputs one-to-one | circuit 1 went `0 → 1 → 0` following the light, circuits 0 and 2 unaffected |
| Sibling programs | resent with **their own real modes**, never nulled | two full pushes observed; all three programs carried modes `1 / 1 / 0` and `1 / 0 / 0` |

Round trip is fast: the module dialogued 3 s after the push and the cloud status was current ~20 s later.

## Changes

**`switch.py`** (new) — one switch per non-filtration program of a module.

- `is_on` reads the live circuit state from the `pool` payload. If the hardware does not answer the live status endpoint, it falls back to the programmed mode, and the `state_source` attribute says which of the two is in use.
- `async_turn_on` / `async_turn_off` write `mode = 1` / `mode = 0`, matching what the vendor apps do.
- **No hardcoded program-type table.** Every non-filtration program yields an entity; `programType` only selects a nicer name when it is known. On the test hardware the third circuit is a `programType: 5`, while #151 reports an `8` for a water blade — enumerating types would have silently dropped one or the other. Unknown types are labelled from the board output name (`Station 3`).
- A 30 s delayed refresh after a write, mirroring the existing filtration select, since the command travels cloud → gateway → LoRa.

**`api.py`** — `async_set_filtration_mode` is generalised into `async_set_program_mode`; the old name stays as a thin wrapper. The API flow is unchanged (`updatePrograms` → module push → both reports → LoRaWAN sync for V2). Target program matched on `id`, falling back to `index`.

**Behaviour change worth reviewing:** sibling programs are no longer sent with `programCharacteristics.mode = None`. As the table above shows, the vendor apps resend every program with its real mode. With the previous behaviour, changing the filtration mode from Home Assistant pushed a null mode onto the spotlight and auxiliary programs. This required rewriting `test_set_filtration_mode_clears_mode_on_non_filtration`, which asserted the old behaviour — it is replaced by a test asserting that siblings keep their own mode, plus a test that the caller's dict is not mutated in place.

**`parser.py`** — the `pool` list is parsed for every index instead of index 0 only. Index 0 keeps its filtration-specific attributes (schedule, remaining time) unchanged.

**`const.py`, `strings.json`, `translations/`, `__init__.py`, `README.md`** — constants, translation keys, `Platform.SWITCH`, docs.

## Why a plain switch and not a three-state select

The hardware mode is tri-state (Off / On / Auto) and #151 proposed a `select`. This PR deliberately ships a `switch` instead, for simplicity: a switch is what a user expects for a pool light, it works with voice assistants, tile cards, and `homeassistant.toggle` without any extra mapping, and it keeps the entity model obvious.

The trade-off is explicit: a switch cannot return a circuit to Auto, so pressing it on a program that was scheduled replaces the schedule with a permanent On or Off until Auto is restored from the vendor app. To keep that visible rather than hidden, the real mode is exposed as a `program_mode` attribute (`off` / `on` / `auto`), so an automation can read it and restore Auto if needed.

If you would rather expose the full tri-state, the natural follow-up is a `select` per circuit alongside these switches, reusing the same `async_set_program_mode`. Happy to add it in this PR if you prefer that shape.

## Testing

- `uv run pytest tests` — 129 passed, coverage 99.86 % (`switch.py` at 100 %)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- Deployed on a real HAOS instance against real hardware: both switches appear with `state_source: circuit`, turning the spotlight on lit it (state confirmed 16 s later), turning it off cleared it (12 s), and the filtration select and binary sensor were untouched across both writes.
- The vendor app reflects the change as its own: after Home Assistant switched the spotlight off, the toggle in the MyIndygo app moved to Off by itself. The two interfaces stay in agreement because the program remains the single source of truth — which is also why the program path was preferred over `setManualCommandToSend`, whose immediate on/off would have left the app showing a stopped program while the light was lit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
