### PR TITLE
chore(api): identify the client with a named User-Agent

### DIFF
--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -17,11 +17,18 @@ from typing import Any
 
 import aiohttp
 
-from .const import LOGGER
+from .const import LOGGER, VERSION
 from .models import IndygoPoolData
 from .parser import IndygoParser
 
 BASE_URL = "https://myindygo.com"
+
+# Identify this client honestly on every request.  Without it aiohttp sends its
+# own default ("Python/3.x aiohttp/3.x"), which tells MyIndygo nothing except
+# that an unidentified script is talking to them.  A named client can be
+# recognised, contacted and rate-limited on its own terms; it also avoids ever
+# passing for the vendor's own app, which sending their user agent would do.
+USER_AGENT = f"ha-indygo-pool/{VERSION} (+https://github.com/FunFR/ha-indygo-pool)"
 
 # OAuth2 client credentials extracted from the Android APK (production).
 _OAUTH2_CLIENT_ID = "5d1c5bb0b4acd1c748988085"
@@ -84,7 +91,10 @@ class IndygoPoolApiClient:
         try:
             async with self._session.post(
                 f"{BASE_URL}/oauth2/token",
-                headers={"Authorization": f"Basic {_OAUTH2_BASIC}"},
+                headers={
+                    "Authorization": f"Basic {_OAUTH2_BASIC}",
+                    "User-Agent": USER_AGENT,
+                },
                 json={
                     "grant_type": "password",
                     "username": self._email,
@@ -159,6 +169,7 @@ class IndygoPoolApiClient:
         request_headers: dict[str, str] = {
             "Authorization": self._token,
             "Accept": "version=2.7",
+            "User-Agent": USER_AGENT,
         }
         if headers:
             request_headers.update(headers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ from yarl import URL
 
 from custom_components.indygo_pool.api import (
     BASE_URL,
+    USER_AGENT,
     IndygoPoolApiClient,
     IndygoPoolApiClientAuthenticationError,
     IndygoPoolApiClientCommunicationError,
@@ -153,6 +154,50 @@ async def test_login_success():
             )
             await client.async_login()
             assert client._token == "Bearer fake_access_token"
+
+
+@pytest.mark.asyncio
+async def test_login_sends_user_agent():
+    """The token request identifies this client rather than aiohttp."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    with aioresponses() as m:
+        m.post(f"{BASE_URL}/oauth2/token", payload=TOKEN_RESPONSE)
+
+        async with aiohttp.ClientSession() as session:
+            client = IndygoPoolApiClient(
+                "test@example.com", "pass", TEST_POOL_ID, session
+            )
+            await client.async_login()
+
+        req = m.requests[("POST", URL(f"{BASE_URL}/oauth2/token"))][0]
+        assert req.kwargs["headers"]["User-Agent"] == USER_AGENT
+
+
+@pytest.mark.asyncio
+async def test_authenticated_request_sends_user_agent():
+    """Every authenticated call carries the same identification."""
+    if aioresponses is None:
+        pytest.skip("aioresponses not installed")
+
+    with aioresponses() as m:
+        m.post(f"{BASE_URL}/api/getPoolStatus", payload={})
+
+        async with aiohttp.ClientSession() as session:
+            client = _make_client(session)
+            await client._fetch_pool_status()
+
+        req = m.requests[("POST", URL(f"{BASE_URL}/api/getPoolStatus"))][0]
+        assert req.kwargs["headers"]["User-Agent"] == USER_AGENT
+
+
+def test_user_agent_names_the_project_and_its_version():
+    """The header stays honest: our name, our version, our repository."""
+    assert USER_AGENT.startswith("ha-indygo-pool/")
+    assert "github.com/FunFR/ha-indygo-pool" in USER_AGENT
+    assert "aiohttp" not in USER_AGENT
+    assert "okhttp" not in USER_AGENT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The integration currently sends no `User-Agent`, so aiohttp supplies its own: `Python/3.13 aiohttp/3.x`. From MyIndygo's side that is an unidentified script hitting their private endpoints. This adds:

```
ha-indygo-pool/2.4.0 (+https://github.com/FunFR/ha-indygo-pool)
```

on the token request and on every authenticated call. The string is built from the manifest version, so it follows releases on its own.

## Why name ourselves rather than stay quiet

This is deliberately *not* the vendor app's user agent. Sending theirs would make our traffic indistinguishable from their own client — a different matter entirely, and much harder to defend if the question is ever raised.

Naming ourselves gives them something to act on: they can recognise the integration, rate-limit it on its own terms, or get in touch. All of those are better outcomes for users than being lumped in with anonymous scraping, which tends to get cut without warning.

A test asserts the header never contains `aiohttp` or `okhttp`, so neither a refactor that drops the header nor one that borrows the vendor's can pass unnoticed.

## Scope

Independent of #200 — this branches from `main` and touches different lines.

An earlier revision of this PR also lowered the polling interval from 5 to 15 minutes. That commit has been dropped to keep this change single-purpose; the polling question can be raised separately if you think it is worth it.

## Testing

- `uv run pytest tests` — 108 passed, coverage 99.84 %
- `uv run ruff check .` and `ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
