### PR TITLE
fix(select): make delayed-refresh timer a proper HA callback

### DIFF
--- a/custom_components/indygo_pool/select.py
+++ b/custom_components/indygo_pool/select.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 
@@ -124,6 +124,7 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
         # the command has propagated through cloud → gateway → LoRa.
         self._schedule_delayed_refresh()
 
+    @callback
     def _schedule_delayed_refresh(self) -> None:
         """Schedule a coordinator refresh after a delay."""
         if self._cancel_delayed_refresh:
@@ -132,10 +133,26 @@ class IndygoPoolSelect(IndygoPoolEntity, SelectEntity):
         self._cancel_delayed_refresh = async_call_later(
             self.hass,
             DELAYED_REFRESH_SECONDS,
-            self._async_delayed_refresh,
+            self._delayed_refresh_callback,
         )
 
-    async def _async_delayed_refresh(self, _now: object) -> None:
-        """Perform the delayed coordinator refresh."""
+    @callback
+    def _delayed_refresh_callback(self, _now: object) -> None:
+        """Fire the delayed coordinator refresh.
+
+        Invoked by ``async_call_later`` in the event loop, so it stays
+        synchronous and hands the awaitable work to a task.
+        """
         self._cancel_delayed_refresh = None
-        await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(self.coordinator.async_request_refresh())
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel a pending delayed refresh when the entity goes away.
+
+        Without this, unloading or reloading the integration during the
+        delay window leaves the timer armed and it fires on a dead entity.
+        """
+        if self._cancel_delayed_refresh:
+            self._cancel_delayed_refresh()
+            self._cancel_delayed_refresh = None
+        await super().async_will_remove_from_hass()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -163,7 +163,13 @@ class TestIndygoPoolSelect:
 
     @pytest.mark.asyncio
     async def test_delayed_refresh_callback(self, mock_coordinator):
-        """Test the delayed refresh callback triggers a coordinator refresh."""
+        """The timer target must work the way HA invokes it: a plain call.
+
+        ``async_call_later`` expects a synchronous ``@callback``, not a
+        coroutine function. Awaiting the target directly only proves a
+        coroutine can be awaited, not that the scheduler's synchronous call
+        works.
+        """
         module_id = "mod1"
         mock_coordinator.data.modules = {
             module_id: IndygoModuleData(
@@ -175,18 +181,56 @@ class TestIndygoPoolSelect:
         }
 
         entity = IndygoPoolSelect(mock_coordinator, module_id, "Pump")
+        entity.hass = MagicMock()
 
         with patch(
             "custom_components.indygo_pool.select.async_call_later"
         ) as mock_call_later:
             await entity.async_select_option(MODE_ON)
 
-        # Extract and call the delayed refresh callback
-        callback = mock_call_later.call_args[0][2]
-        mock_coordinator.async_request_refresh.reset_mock()
-        await callback(None)
+        timer_target = mock_call_later.call_args[0][2]
+        assert timer_target(None) is None
 
-        mock_coordinator.async_request_refresh.assert_called_once()
+        assert entity._cancel_delayed_refresh is None
+        entity.hass.async_create_task.assert_called_once()
+        # Close the coroutine handed to the task so it is not left un-awaited.
+        entity.hass.async_create_task.call_args[0][0].close()
+
+    @pytest.mark.asyncio
+    async def test_removal_cancels_pending_refresh(self, mock_coordinator):
+        """Unloading during the delay window disarms the timer."""
+        module_id = "mod1"
+        mock_coordinator.data.modules = {
+            module_id: IndygoModuleData(
+                id=module_id,
+                type="lr-pc",
+                name="Pump",
+                filtration_program={"programCharacteristics": {"mode": 0}},
+            )
+        }
+
+        entity = IndygoPoolSelect(mock_coordinator, module_id, "Pump")
+        entity.hass = MagicMock()
+
+        cancel_cb = MagicMock()
+        with patch(
+            "custom_components.indygo_pool.select.async_call_later",
+            return_value=cancel_cb,
+        ):
+            await entity.async_select_option(MODE_ON)
+
+        await entity.async_will_remove_from_hass()
+
+        cancel_cb.assert_called_once()
+        assert entity._cancel_delayed_refresh is None
+
+    @pytest.mark.asyncio
+    async def test_removal_without_pending_refresh_is_a_no_op(self, mock_coordinator):
+        """Removing an idle entity must not raise."""
+        entity = IndygoPoolSelect(mock_coordinator, "mod1", "Pump")
+
+        await entity.async_will_remove_from_hass()
+
         assert entity._cancel_delayed_refresh is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The switch.py review on #200 caught two issues in its delayed-refresh timer that select.py has too, since switch.py was mirrored from it: the timer target wasn't a synchronous \`@callback\` (\`async_call_later\` expects one, not a coroutine function), and a pending timer wasn't cancelled on entity removal, so it could fire on a dead entity.

Mirrors the same fix applied to switch.py: the scheduler and the timer target are both \`@callback\`, the target hands the refresh to a task instead of awaiting it, and \`async_will_remove_from_hass\` cancels any pending timer.

The existing \`test_delayed_refresh_callback\` awaited the timer target directly, which only proved a coroutine can be awaited, not that the scheduler's synchronous call works. It now calls the target exactly as \`async_call_later\` does.