### PR TITLE
fix(switch): report the requested state while the board catches up

### DIFF
--- a/custom_components/indygo_pool/switch.py
+++ b/custom_components/indygo_pool/switch.py
@@ -9,6 +9,7 @@ published by the board.
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -33,7 +34,18 @@ from .models import IndygoModuleData
 # Delay (seconds) before a follow-up refresh after a mode change.  The command
 # travels cloud → gateway → LoRa → device and the device then reports back, so
 # the status endpoint keeps returning the old state for a short while.
-DELAYED_REFRESH_SECONDS = 30
+# Follow-up reads after a write.  Round trips of 12 s, 16 s and 86 s have been
+# measured on real hardware, so a single shot cannot cover the range: too early
+# and it reads the old state, too late and the entity stays stale until the
+# next poll.  Three staged reads span the measured spread at the cost of two
+# extra requests per command.
+DELAYED_REFRESH_SCHEDULE = (15, 45, 90)
+
+# How long the entity keeps reporting the requested state while waiting for the
+# board to confirm it.  Deliberately past the last follow-up read, and bounded:
+# beyond it, a command that never took effect must stop being reported as if it
+# had.
+OPTIMISTIC_TIMEOUT_SECONDS = 150
 
 # Human-readable mode, exposed as an attribute so automations can tell an
 # explicit On/Off from a scheduled Auto.
@@ -144,7 +156,11 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
             self._attr_translation_placeholders = translation_placeholders
         self._attr_unique_id = self._build_unique_id(f"circuit_{circuit_index}")
         self.entity_id = f"switch.{self.device_name_slug}_{entity_suffix}"
-        self._cancel_delayed_refresh: CALLBACK_TYPE | None = None
+        self._pending_refreshes: list[CALLBACK_TYPE] = []
+        # Requested state, held until the board confirms it or the window
+        # expires.  See `is_on`.
+        self._optimistic: bool | None = None
+        self._optimistic_expires: float = 0.0
 
     # ------------------------------------------------------------------
     # Data helpers
@@ -196,9 +212,37 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
     # Entity
     # ------------------------------------------------------------------
 
+    def _optimistic_value(self) -> bool | None:
+        """Return the pending requested state, or None if it no longer holds.
+
+        Clears itself once the board reports the requested value, or once the
+        window elapses — so a command that never took effect surfaces as the
+        real state instead of lying indefinitely.
+        """
+        if self._optimistic is None:
+            return None
+        if time.monotonic() >= self._optimistic_expires:
+            self._optimistic = None
+            return None
+        if self._circuit_state is self._optimistic:
+            self._optimistic = None
+            return None
+        return self._optimistic
+
     @property
     def is_on(self) -> bool | None:
         """Return true if the circuit is powered."""
+        # A command takes cloud → gateway → LoRa → board and back: measured
+        # between 12 s and 86 s.  Reporting the stale state during that window
+        # makes any controller that expects prompt confirmation — HomeKit in
+        # particular — treat the command as failed and retry it in a burst,
+        # while the user taps again.  Every one of those is a real write, so
+        # the board later replays the whole sequence and the light appears to
+        # switch itself off.  Hold the requested state until the board agrees.
+        optimistic = self._optimistic_value()
+        if optimistic is not None:
+            return optimistic
+
         state = self._circuit_state
         if state is not None:
             return state
@@ -215,12 +259,16 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         mode = self._mode
+        if self._optimistic_value() is not None:
+            source = "optimistic"
+        elif self._circuit_state is not None:
+            source = "circuit"
+        else:
+            source = "program_mode"
         return {
             "circuit_index": self._circuit_index,
             "program_mode": PROGRAM_MODE_NAMES.get(mode, mode),
-            "state_source": (
-                "circuit" if self._circuit_state is not None else "program_mode"
-            ),
+            "state_source": source,
         }
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -246,38 +294,50 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
             self._module_id, program, mode
         )
 
+        # Report the requested state at once. Only after the write succeeded:
+        # a failed command must not leave the entity claiming a state the
+        # board never reached.
+        self._optimistic = mode == PROGRAM_MODE_ON
+        self._optimistic_expires = time.monotonic() + OPTIMISTIC_TIMEOUT_SECONDS
+        self.async_write_ha_state()
+
         await self.coordinator.async_request_refresh()
         self._schedule_delayed_refresh()
 
     @callback
     def _schedule_delayed_refresh(self) -> None:
-        """Schedule a coordinator refresh after a delay."""
-        if self._cancel_delayed_refresh:
-            self._cancel_delayed_refresh()
+        """Arm the follow-up reads that catch the board's confirmation."""
+        self._cancel_pending_refreshes()
+        for delay in DELAYED_REFRESH_SCHEDULE:
+            self._pending_refreshes.append(
+                async_call_later(self.hass, delay, self._delayed_refresh_callback)
+            )
 
-        self._cancel_delayed_refresh = async_call_later(
-            self.hass,
-            DELAYED_REFRESH_SECONDS,
-            self._delayed_refresh_callback,
-        )
+    @callback
+    def _cancel_pending_refreshes(self) -> None:
+        """Drop every armed follow-up read.
+
+        Cancelling a timer that already fired is a no-op, so handles are not
+        tracked individually.
+        """
+        for cancel in self._pending_refreshes:
+            cancel()
+        self._pending_refreshes.clear()
 
     @callback
     def _delayed_refresh_callback(self, _now: object) -> None:
-        """Fire the delayed coordinator refresh.
+        """Fire one follow-up read.
 
         Invoked by ``async_call_later`` in the event loop, so it stays
         synchronous and hands the awaitable work to a task.
         """
-        self._cancel_delayed_refresh = None
         self.hass.async_create_task(self.coordinator.async_request_refresh())
 
     async def async_will_remove_from_hass(self) -> None:
-        """Cancel a pending delayed refresh when the entity goes away.
+        """Cancel pending reads when the entity goes away.
 
-        Without this, unloading or reloading the integration during the
-        30 s window leaves the timer armed and it fires on a dead entity.
+        Without this, unloading or reloading the integration inside the
+        follow-up window leaves timers armed, firing on a dead entity.
         """
-        if self._cancel_delayed_refresh:
-            self._cancel_delayed_refresh()
-            self._cancel_delayed_refresh = None
+        self._cancel_pending_refreshes()
         await super().async_will_remove_from_hass()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,6 +13,7 @@ from custom_components.indygo_pool.models import (
     IndygoSensorData,
 )
 from custom_components.indygo_pool.switch import (
+    DELAYED_REFRESH_SCHEDULE,
     IndygoPoolCircuitSwitch,
     async_setup_entry,
 )
@@ -69,14 +70,21 @@ def _module(pool_status: dict | None = None) -> IndygoModuleData:
 
 
 def _switch(coordinator, index: int = 1) -> IndygoPoolCircuitSwitch:
-    """Build a switch for a given circuit index."""
-    return IndygoPoolCircuitSwitch(
+    """Build a switch for a given circuit index.
+
+    Standalone entity, with no state machine behind it: writing state is
+    stubbed.  The optimistic behaviour itself is asserted through ``is_on``.
+    """
+    entity = IndygoPoolCircuitSwitch(
         coordinator=coordinator,
         module_id="mod1",
         circuit_index=index,
         translation_key="spotlight",
         entity_suffix="spotlight",
     )
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    return entity
 
 
 class TestSetup:
@@ -297,11 +305,25 @@ class TestCommands:
         mock_coordinator.client.async_set_program_mode.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_delayed_refresh_is_rescheduled(self, mock_coordinator):
-        """A second command cancels the pending delayed refresh."""
+    async def test_one_read_is_armed_per_stage(self, mock_coordinator):
+        """A single shot cannot span 12 s to 86 s round trips — three do."""
         mock_coordinator.data.modules = {"mod1": _module()}
         entity = _switch(mock_coordinator)
-        entity.hass = MagicMock()
+
+        with patch(
+            "custom_components.indygo_pool.switch.async_call_later"
+        ) as mock_call_later:
+            await entity.async_turn_on()
+
+        delays = [call[0][1] for call in mock_call_later.call_args_list]
+        assert delays == list(DELAYED_REFRESH_SCHEDULE)
+        assert len(entity._pending_refreshes) == len(DELAYED_REFRESH_SCHEDULE)
+
+    @pytest.mark.asyncio
+    async def test_delayed_refresh_is_rescheduled(self, mock_coordinator):
+        """A second command disarms every read the first one armed."""
+        mock_coordinator.data.modules = {"mod1": _module()}
+        entity = _switch(mock_coordinator)
 
         cancel_cb = MagicMock()
         with patch(
@@ -312,7 +334,7 @@ class TestCommands:
             cancel_cb.assert_not_called()
 
             await entity.async_turn_off()
-            cancel_cb.assert_called_once()
+            assert cancel_cb.call_count == len(DELAYED_REFRESH_SCHEDULE)
 
     @pytest.mark.asyncio
     async def test_delayed_refresh_callback(self, mock_coordinator):
@@ -325,7 +347,6 @@ class TestCommands:
         """
         mock_coordinator.data.modules = {"mod1": _module()}
         entity = _switch(mock_coordinator)
-        entity.hass = MagicMock()
 
         with patch(
             "custom_components.indygo_pool.switch.async_call_later"
@@ -335,17 +356,15 @@ class TestCommands:
         timer_target = mock_call_later.call_args[0][2]
         assert timer_target(None) is None
 
-        assert entity._cancel_delayed_refresh is None
         entity.hass.async_create_task.assert_called_once()
         # Close the coroutine handed to the task so it is not left un-awaited.
         entity.hass.async_create_task.call_args[0][0].close()
 
     @pytest.mark.asyncio
     async def test_removal_cancels_pending_refresh(self, mock_coordinator):
-        """Unloading during the delay window disarms the timer."""
+        """Unloading inside the follow-up window disarms every read."""
         mock_coordinator.data.modules = {"mod1": _module()}
         entity = _switch(mock_coordinator)
-        entity.hass = MagicMock()
 
         cancel_cb = MagicMock()
         with patch(
@@ -356,8 +375,8 @@ class TestCommands:
 
         await entity.async_will_remove_from_hass()
 
-        cancel_cb.assert_called_once()
-        assert entity._cancel_delayed_refresh is None
+        assert cancel_cb.call_count == len(DELAYED_REFRESH_SCHEDULE)
+        assert entity._pending_refreshes == []
 
     @pytest.mark.asyncio
     async def test_removal_without_pending_refresh_is_a_no_op(self, mock_coordinator):
@@ -367,7 +386,104 @@ class TestCommands:
 
         await entity.async_will_remove_from_hass()
 
-        assert entity._cancel_delayed_refresh is None
+        assert entity._pending_refreshes == []
+
+
+class TestOptimisticState:
+    """The requested state is reported until the board confirms it.
+
+    Without this, a controller that expects prompt confirmation — HomeKit —
+    reads the stale state, calls the command failed and retries in a burst.
+    """
+
+    @pytest.mark.asyncio
+    async def test_turn_on_reports_on_before_the_board_agrees(self, mock_coordinator):
+        """The board still says 0, the switch already says on."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=0)})
+        }
+        entity = _switch(mock_coordinator)
+        assert entity.is_on is False
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_on()
+
+        assert entity.is_on is True
+        assert entity.extra_state_attributes["state_source"] == "optimistic"
+
+    @pytest.mark.asyncio
+    async def test_turn_off_reports_off_before_the_board_agrees(self, mock_coordinator):
+        """Symmetric: the board still says 1, the switch already says off."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=1)})
+        }
+        entity = _switch(mock_coordinator)
+        assert entity.is_on is True
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_off()
+
+        assert entity.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_optimistic_clears_once_the_board_confirms(self, mock_coordinator):
+        """When the board catches up, the entity goes back to reporting it."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=0)})
+        }
+        entity = _switch(mock_coordinator)
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_on()
+
+        # The board now reports the circuit powered.
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=1)})
+        }
+
+        assert entity.is_on is True
+        assert entity.extra_state_attributes["state_source"] == "circuit"
+        assert entity._optimistic is None
+
+    @pytest.mark.asyncio
+    async def test_optimistic_expires_when_the_command_never_lands(
+        self, mock_coordinator
+    ):
+        """A command that never took effect must stop being reported as if it had."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=0)})
+        }
+        entity = _switch(mock_coordinator)
+
+        with patch("custom_components.indygo_pool.switch.async_call_later"):
+            await entity.async_turn_on()
+        assert entity.is_on is True
+
+        # Well past the window, board still reporting 0.
+        entity._optimistic_expires = 0.0
+
+        assert entity.is_on is False
+        assert entity.extra_state_attributes["state_source"] == "circuit"
+
+    @pytest.mark.asyncio
+    async def test_failed_write_leaves_no_optimistic_state(self, mock_coordinator):
+        """A write that raised must not leave the entity claiming success."""
+        mock_coordinator.data.modules = {
+            "mod1": _module({"1": IndygoSensorData(key="circuit_1_status", value=0)})
+        }
+        mock_coordinator.client.async_set_program_mode.side_effect = RuntimeError(
+            "nope"
+        )
+        entity = _switch(mock_coordinator)
+
+        with (
+            patch("custom_components.indygo_pool.switch.async_call_later"),
+            pytest.raises(RuntimeError),
+        ):
+            await entity.async_turn_on()
+
+        assert entity._optimistic is None
+        assert entity.is_on is False
 
 
 def test_unique_id_is_stable_per_circuit(mock_coordinator):


### PR DESCRIPTION
Follow-up to #200. I exposed the spotlight switch to HomeKit through Home Assistant's **HomeKit Bridge**, so my partner can use it from her iPhone — she only uses the Home app. That is how this surfaced: the light takes a long time to come on, then **switches itself off**, repeatedly.

The fault is not HomeKit's. It comes from the entity reporting hardware state without ever anticipating the command — and the hardware is slow.

## What the logbook shows

A real sequence, from the logbook (local time):

```
16:41:11  HomeKit → turn_on      she taps
16:41:49  HomeKit → turn_on      nothing happens, she taps again
16:42:30  HomeKit → turn_off     she toggles back, thinking she is cancelling
16:42:37  state → ON             ← the 16:41:11 command landing, 86 s later
16:42:38  HomeKit → turn_on
16:43:04  HomeKit → turn_off
16:43:15  HomeKit → turn_off
16:43:50  state → OFF            ← the 16:42:30 turn_off landing
```

The light is not switching itself off: it is replaying, a minute late, a command sent while the user believed nothing was happening.

And then this:

```
16:44:13.468 → 16:44:13.780     ELEVEN turn_on in 312 milliseconds
17:33:24.108 → 17:33:24.207     NINE turn_on in 99 milliseconds
```

No human taps eleven times in a third of a second. That is the HomeKit controller **retrying**: it asked for "on", the accessory keeps answering "off", it concludes the command failed. Every retry is a real write to MyIndygo — roughly 44 API calls in a third of a second — and the board then replays the whole sequence.

## Measured round trips

Command → confirmation by the board, on an `lr-pc`:

| When | Delay |
|---|---|
| Aug 1, quiet | 12 s and 16 s |
| Aug 7, loaded | **86 s** |
| Aug 7, after this fix | 25 s |

## What this PR changes

**1. The entity reports the requested state while the board catches up.**

Set **after** the write succeeded — a rejected command must not make the entity lie. The optimistic state clears itself as soon as the board confirms, or after 150 s if the command never landed. `state_source` reads `optimistic` during that window, so the assumption stays visible rather than passing for a measurement.

**2. Follow-up reads are staged: 15 s, 45 s, 90 s.**

A single shot at 30 s cannot span a 12 s to 86 s range: too early it reads the old state, too late the entity stays stale until the 5-minute poll. This is also what was masking the problem — HomeKit's retry burst generated a read per command, which acted as a safety net. Removing the burst removes the net too.

Cost: two extra requests per command, against the 44 that a single tap triggered before.

## Verified on hardware

Same gesture, before and after, from the Home app:

```
before   17:33:24.108 → .207   NINE turn_on in 99 ms, then two turn_off, unstable state
after    18:11:48.765          ONE command, state off at 18:11:50.979
```

One command, no retry, no phantom switch-off. The HomeKit tile flips immediately and holds.

## A note on `select.py`

The same pattern is there — `current_option` reads coordinator data directly, and the write sets no anticipated state. I have not touched it here: you mentioned a PR of your own on that file, and I did not want to widen this one without asking. It is less visible there because a `select` is not exposed to HomeKit as an on/off accessory, but the latency is identical.

## Testing

- `uv run pytest tests` — 142 passed, coverage 99.87 %, `switch.py` at 100 %
- `uv run ruff check .` and `ruff format --check .` — clean
- 7 new tests, including: the optimistic state clears when the board confirms, it expires when the command never lands, and **a write that raises leaves no optimistic state behind**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
