### PR TITLE
fix: make internal helpers keyword-only to satisfy PLR0917

### DIFF
--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -143,6 +143,7 @@ class IndygoPoolApiClient:
         self,
         method: str,
         url: str,
+        *,
         headers: dict | None = None,
         data: str | None = None,
         json_body: dict | None = None,

--- a/custom_components/indygo_pool/switch.py
+++ b/custom_components/indygo_pool/switch.py
@@ -128,6 +128,7 @@ class IndygoPoolCircuitSwitch(IndygoPoolEntity, SwitchEntity):
 
     def __init__(
         self,
+        *,
         coordinator: IndygoPoolDataUpdateCoordinator,
         module_id: str,
         circuit_index: int,


### PR DESCRIPTION
ruff's PL ruleset flags \`_request\` and \`IndygoPoolCircuitSwitch.__init__\` for exceeding 5 positional arguments (PLR0917). All call sites already pass these as keywords, so making them keyword-only fixes the lint without touching behavior.