### PR TITLE
fix(ci): autolabel PRs so the release changelog is actually categorized

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,23 +25,24 @@ autolabeler:
       - "/^renovate\\//i"
 
 categories:
-  - title: "Breaking Changes"
+  - title: "💥 Breaking Changes"
     labels:
       - "breaking"
-  - title: "Features"
+  - title: "🚀 Features"
     labels:
       - "feature"
       - "enhancement"
-  - title: "Bug Fixes"
+  - title: "🐛 Bug Fixes"
     labels:
       - "bug"
       - "fix"
-  - title: "Maintenance"
+  - title: "🧰 Maintenance"
     labels:
       - "chore"
       - "ci"
       - "dependencies"
       - "refactor"
+    collapse-after: 5
 
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,9 +21,7 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
-        with:
-          disable-releaser: true
+      - uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

The draft release changelog (e.g. [v2.5.0](https://github.com/FunFR/ha-indygo-pool/releases/tag/untagged-5f46936b6e591e7efcc5)) is a flat, ~40-line list dominated by Renovate dependency bumps, with real fixes buried in the middle.

## Root cause

`release-drafter` v7 split PR autolabeling out into a separate `autolabeler` sub-action. The `label-pr` job here still calls the root `release-drafter/release-drafter` action (which only drafts releases) with a `disable-releaser` input that doesn't exist in v7 (silently ignored, logged as a warning). So no PR has ever been labeled, and every change falls into the same uncategorized bucket regardless of the `categories` config.

## Changes

- `label-pr` job now calls `release-drafter/release-drafter/autolabeler@<sha> # v7`, the action actually responsible for applying labels from the `autolabeler` config.
- Added `collapse-after: 5` to the Maintenance category so dependency/chore/ci noise folds into a `<details>` block instead of dominating the notes.
- Added emoji prefixes to category titles, matching the convention used by other HACS-distributed integrations.

## Note

Already-merged PRs won't be retroactively relabeled by this fix (autolabeling only runs on PR open/sync/label events). The next PR going through the labeled flow will start populating categories correctly; historical entries in the current draft stay as-is until it's regenerated from a clean state.

## Test plan

- [ ] Confirm the `label-pr` job succeeds and applies a label to a test PR
- [ ] Confirm the next push to `main` produces a categorized draft release with the Maintenance section collapsed