### PR TITLE
ci: highlight external contributors in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -47,6 +47,12 @@ categories:
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
 
+exclude-contributors:
+  - "FunFR"
+  - "renovate"
+  - "github-actions"
+no-contributors-template: "_No external contributions in this release._"
+
 version-resolver:
   major:
     labels:
@@ -69,5 +75,9 @@ template: |
   ## What's Changed
 
   $CHANGES
+
+  ## 🙌 External Contributors
+
+  $CONTRIBUTORS
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
## Description

Adds a dedicated "External Contributors" section to the release notes template, using release-drafter's `$CONTRIBUTORS` variable.

## Changes

- `exclude-contributors`: excludes the maintainer (`FunFR`) and bots (`renovate`, `github-actions`) so the section only surfaces community contributions.
- `no-contributors-template`: clean fallback sentence when a release has no external contributors, instead of an empty section.
- New `## 🙌 External Contributors` block in the release template.

## Test plan

- [ ] Confirm the next drafted release shows a populated "External Contributors" section for PRs from non-maintainer accounts (e.g. @zakhounet)
- [ ] Confirm a release with only maintainer/bot PRs shows the fallback sentence instead of an empty heading