### PR TITLE
ci: exclude Cursor's AI co-author account from release contributors

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -51,6 +51,7 @@ exclude-contributors:
   - "FunFR"
   - "renovate"
   - "github-actions"
+  - "cursoragent"
 no-contributors-template: "_No external contributions in this release._"
 
 version-resolver:


### PR DESCRIPTION
## Problem

The draft v2.5.0 release notes' new "External Contributors" section (#212) listed `@cursoragent` alongside the genuine external contributor `@zakhounet`.

## Cause

PR #167 has a docs commit with a `Co-authored-by: Cursor <cursoragent@cursor.com>` trailer, added by the maintainer's own tooling. release-drafter's `$CONTRIBUTORS` pulls contributors from commit co-authors as well as PR authors, so it picked this up as if it were an external contribution.

## Fix

Add `cursoragent` to `exclude-contributors`, same treatment as the maintainer and CI bots.