### PR TITLE
fix: degrade to sensor-only mode when no lr-pc/ipx module is found

### DIFF
--- a/custom_components/indygo_pool/api.py
+++ b/custom_components/indygo_pool/api.py
@@ -78,6 +78,7 @@ class IndygoPoolApiClient:
         self._pool_address: str | None = None
         self._device_short_id: str | None = None
         self._relay_id: str | None = None
+        self._hardware_resolved = False
 
         # Cached rich data
         self._data: IndygoPoolData | None = None
@@ -286,8 +287,13 @@ class IndygoPoolApiClient:
         )
 
     async def _resolve_hardware_ids(self, modules: list[dict]) -> None:
-        """Resolve pool_address, device_short_id and relay_id from modules."""
-        if self._pool_address and self._device_short_id and self._relay_id:
+        """Resolve pool_address, device_short_id and relay_id from modules.
+
+        No lr-pc/ipx module (e.g. LR-MB gateway + Pool Guard² only) means
+        nothing to control, but root sensors still work — degrade instead
+        of failing setup.
+        """
+        if self._hardware_resolved:
             return
 
         pool_address, device_short_id, relay_id = self._parser.resolve_hardware_ids(
@@ -295,14 +301,18 @@ class IndygoPoolApiClient:
         )
 
         if not pool_address or not device_short_id or not relay_id:
-            raise IndygoPoolApiClientError(
-                "Could not determine Pool Address, Device Short ID, or Relay ID "
-                f"from {len(modules)} modules."
+            LOGGER.warning(
+                "No lr-pc/ipx module found in %d modules — falling back to "
+                "sensor-only mode (no filtration/relay control available).",
+                len(modules),
             )
+            self._hardware_resolved = True
+            return
 
         self._pool_address = pool_address
         self._device_short_id = device_short_id
         self._relay_id = relay_id
+        self._hardware_resolved = True
 
     async def async_get_data(self) -> IndygoPoolData:
         """Get data from the API."""
@@ -326,17 +336,19 @@ class IndygoPoolApiClient:
         status_data = await self._fetch_pool_status()
 
         # 4b. Merge pump circuit data from device endpoint when available.
-        # Some hardware returns 408 — skip gracefully in that case.
-        try:
-            device_status = await self._fetch_device_status()
-            for key in ("pool", "sensorState", "dialogTimeStamp"):
-                if key in device_status:
-                    status_data[key] = device_status[key]
-        except IndygoPoolApiClientCommunicationError:
-            LOGGER.debug(
-                "Device status endpoint unavailable for %s — pump circuits skipped",
-                self._pool_address,
-            )
+        # Some hardware returns 408 — skip gracefully in that case. Sensor-only
+        # hardware has no pool_address/device_short_id to query at all.
+        if self._pool_address and self._device_short_id:
+            try:
+                device_status = await self._fetch_device_status()
+                for key in ("pool", "sensorState", "dialogTimeStamp"):
+                    if key in device_status:
+                        status_data[key] = device_status[key]
+            except IndygoPoolApiClientCommunicationError:
+                LOGGER.debug(
+                    "Device status endpoint unavailable for %s — pump circuits skipped",
+                    self._pool_address,
+                )
 
         # 5. Merge modules metadata into the status data
         status_data["modules"] = modules

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,7 @@ TEST_MODULE_ID = "mod_123"
 TEST_RELAY_ID = "relay_123"
 TEST_POOL_ADDRESS = "pool_123"
 TEST_SERIAL = "SERIAL_ABC"
+TEST_SENSOR_ONLY_TEMP = 31.19
 
 TOKEN_RESPONSE = {
     "access_token": "fake_access_token",
@@ -741,21 +742,47 @@ async def test_get_data_with_ipx_module():
 
 
 @pytest.mark.asyncio
-async def test_get_data_missing_hardware_ids():
-    """Test error when no compatible module found."""
+async def test_get_data_missing_hardware_ids_falls_back_to_sensor_only():
+    """No lr-pc/ipx module (e.g. LR-MB gateway + Pool Guard² only) degrades
+    to sensor-only mode instead of failing setup — see issue #216."""
     if aioresponses is None:
         pytest.skip("aioresponses not installed")
+
+    modules = [
+        {"id": "gw_1", "type": "lr-mb-10", "name": "LRMB10-01", "typeIsRelay": True},
+        {
+            "id": "pg_1",
+            "type": "lr-pg2",
+            "name": "LRPG2-0D0C15",
+            "typeIsSensor": True,
+            "typeIsPoolProduct": True,
+        },
+    ]
 
     with aioresponses() as m:
         m.post(
             f"{BASE_URL}/api/getUserWithHisModules",
-            payload={"modules": [{"id": "x", "type": "unknown"}]},
+            payload={"modules": modules},
+        )
+        m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
+        m.post(f"{BASE_URL}/api/getModuleWithHisPrograms", payload={"programs": []})
+        m.post(
+            f"{BASE_URL}/api/getPoolStatus",
+            payload={
+                "temperature": {"value": TEST_SENSOR_ONLY_TEMP},
+                "lastPhMeasure": {"value": 8.33},
+                "lastRedoxMeasure": {"value": 799},
+            },
         )
 
         async with aiohttp.ClientSession() as session:
             client = _make_client(session)
-            with pytest.raises(IndygoPoolApiClientError, match="Could not determine"):
-                await client.async_get_data()
+            data = await client.async_get_data()
+
+            assert client._pool_address is None
+            assert client._device_short_id is None
+            assert client._relay_id is None
+            assert data.sensors["temperature"].value == TEST_SENSOR_ONLY_TEMP
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Hardware exposing only an LR-MB gateway (`lr-mb-10`) and a Pool Guard² sensor (`lr-pg2`), with no Pool Command relay board, has no `lr-pc`/`ipx` module for `resolve_hardware_ids` to find. That currently raises `IndygoPoolApiClientError` and blocks the config flow entirely, even though root-level sensors (temperature, pH, redox) are already reachable via `getPoolStatus` independently of any module.

This degrades that case to a "sensor-only" mode instead: setup succeeds, sensors populate, and filtration/relay control is simply unavailable (there is nothing to control on this hardware).

Refs: #216

## ✅ Checks

- [ ] Tested against real MyIndygo hardware (list the gateway/device models below, e.g. lr-pc, lr-mb-10, ipx)
- [x] No hardcoded user-facing strings (added to `strings.json` instead)
- [ ] Documentation updated (`README.md`) if behavior or setup changed

## Additional information

No user-facing behavior/setup documentation changed — this only affects an internal fallback for otherwise-unsupported hardware.

Not tested against real lr-mb-10/lr-pg2 hardware — I don't have access to that setup. Covered by a new unit test (`test_get_data_missing_hardware_ids_falls_back_to_sensor_only`) using the module payload shape reported in #216. Would appreciate the reporter testing this against their actual pool before merge.

Left open on purpose: keeping the issue open until the beta release is confirmed working, then closing manually with a comment linking the release.