### PR TITLE
ci: default drafted releases to pre-release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
+prerelease: true
 
 autolabeler:
   - label: "feature"


### PR DESCRIPTION
## Summary

The drafted release currently defaults to a normal (latest) release once published. This sets `prerelease: true` in release-drafter's config so the checkbox defaults to checked at publish time — you still choose when to publish, this only changes the default so a release always gets its beta window before being promoted to latest by unchecking pre-release on the same release.

Refs: follow-up from #219

## ✅ Checks

- [ ] Tested against real MyIndygo hardware (list the gateway/device models below, e.g. lr-pc, lr-mb-10, ipx)
- [x] No hardcoded user-facing strings (added to `strings.json` instead)
- [ ] Documentation updated (`README.md`) if behavior or setup changed

## Additional information

CI-only config change, no runtime code touched.