### PR TITLE
docs: document the batch-merge release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,12 +105,7 @@ scp -r custom_components/indygo_pool root@<HA_IP>:/config/custom_components/
 
 ## 🚀 Release Process
 
-Merging a PR to `main` does not itself publish a release: [Release Drafter](.github/workflows/release-drafter.yml) accumulates every merge (including Renovate's) into a single running **draft** release, bumping the version by label (`breaking`/`feature`/`fix`/etc.) as PRs land. This lets several merges batch into one release instead of one release per merge.
+Merges batch into one running draft ([Release Drafter](.github/workflows/release-drafter.yml)), published manually when ready:
 
-When ready to cut a release:
-
-1. Open the draft under [Releases](https://github.com/FunFR/ha-indygo-pool/releases) and review its changelog.
-2. Publish it. It defaults to **pre-release**, which HACS only surfaces to users with "Show beta versions" enabled; use this window to ask affected users to test.
-3. After it's run a few days with no reports, edit the same release and uncheck "Set as a pre-release". No retagging needed: it becomes the latest release for all HACS users.
-
-Publishing (in either mode) triggers the [release workflow](.github/workflows/release.yml), which stamps the tag's version into `manifest.json` and attaches `indygo_pool.zip`.
+1. Publish the draft under [Releases](https://github.com/FunFR/ha-indygo-pool/releases). Defaults to **pre-release** (HACS beta channel) for a few days of testing.
+2. Edit the same release, uncheck "Set as a pre-release" to promote it to latest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,15 @@ scp -r custom_components/indygo_pool root@<HA_IP>:/config/custom_components/
 - **Fix**: `uv run ruff check --fix .`
 - **Format**: `uv run ruff format .`
 - **Pre-commit**: `uv run pre-commit run --all-files`
+
+## 🚀 Release Process
+
+Merging a PR to `main` does not itself publish a release: [Release Drafter](.github/workflows/release-drafter.yml) accumulates every merge (including Renovate's) into a single running **draft** release, bumping the version by label (`breaking`/`feature`/`fix`/etc.) as PRs land. This lets several merges batch into one release instead of one release per merge.
+
+When ready to cut a release:
+
+1. Open the draft under [Releases](https://github.com/FunFR/ha-indygo-pool/releases) and review its changelog.
+2. Publish it. It defaults to **pre-release**, which HACS only surfaces to users with "Show beta versions" enabled; use this window to ask affected users to test.
+3. After it's run a few days with no reports, edit the same release and uncheck "Set as a pre-release". No retagging needed: it becomes the latest release for all HACS users.
+
+Publishing (in either mode) triggers the [release workflow](.github/workflows/release.yml), which stamps the tag's version into `manifest.json` and attaches `indygo_pool.zip`.


### PR DESCRIPTION
## Summary

There was no written record of how releases actually get cut here: PRs (including Renovate's) merge to `main` continuously, but a release is only published when someone decides to, batching several merges into one. Adds a Release Process section to CONTRIBUTING.md covering that, plus the pre-release-then-promote step enabled by #220.

Refs: follow-up from #219, #220

## ✅ Checks

- [ ] Tested against real MyIndygo hardware (list the gateway/device models below, e.g. lr-pc, lr-mb-10, ipx)
- [x] No hardcoded user-facing strings (added to `strings.json` instead)
- [x] Documentation updated (`README.md`) if behavior or setup changed

## Additional information

Docs-only, no runtime code touched.