### PR TITLE
ci: fix script injection risk in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

`release.yml` interpolated `github.event.release.tag_name` directly into a `run:` shell block via `${{ }}` templating, a known GitHub Actions script-injection pattern (CWE-94): a tag name containing shell metacharacters would execute arbitrary code in a job holding `contents: write`. Passing the value through `env:` instead avoids template-time substitution into the script.

## ✅ Checks

- [x] N/A — CI-only change, no hardware involved
- [x] N/A — no user-facing strings touched
- [x] N/A — no behavior/setup change for users

## Additional information

No functional change to the release process itself.