### PR TITLE
feat: add reauth, reconfigure and options flow to config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Add the integration: [![Add Integration][add-integration-badge]][add-integration
 4. Enter your MyIndygo credentials (email, password) and your **Pool ID**.
     > The **Pool ID** can be found in the URL after logging into myindygo.com (e.g., `https://myindygo.com/pools/<Pool ID>/devices`).
 
+### Reauthentication, reconfiguration and options
+
+- If your MyIndygo password changes, Home Assistant will prompt you to **reauthenticate** instead of requiring you to delete and recreate the integration.
+- To change your email, password or Pool ID after setup, open the integration and select **Reconfigure**.
+- To adjust how often the integration polls the MyIndygo API (default: every 5 minutes), open the integration and select **Configure**.
+
 ## Contributing
 
 We welcome contributions! Please review [CONTRIBUTING.md](CONTRIBUTING.md) for environment setup and pull request guidelines. If you are an AI agent or looking for project architecture rules, refer to [AGENTS.md](AGENTS.md).

--- a/custom_components/indygo_pool/config_flow.py
+++ b/custom_components/indygo_pool/config_flow.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
 from .api import (
     IndygoPoolApiClient,
@@ -12,7 +21,15 @@ from .api import (
     IndygoPoolApiClientCommunicationError,
     IndygoPoolApiClientError,
 )
-from .const import CONF_EMAIL, CONF_PASSWORD, CONF_POOL_ID, DOMAIN, LOGGER
+from .const import (
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    CONF_POOL_ID,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+)
 
 
 class IndygoPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -31,25 +48,12 @@ class IndygoPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_POOL_ID])
             self._abort_if_unique_id_configured()
 
-            try:
-                await self._test_credentials(
-                    email=user_input[CONF_EMAIL],
-                    password=user_input[CONF_PASSWORD],
-                    pool_id=user_input[CONF_POOL_ID],
-                )
-            except IndygoPoolApiClientAuthenticationError:
-                LOGGER.exception("Authentication error during config flow")
-                errors["base"] = "auth"
-            except IndygoPoolApiClientCommunicationError:
-                LOGGER.exception("Communication error during config flow")
-                errors["base"] = "connection"
-            except IndygoPoolApiClientError:
-                LOGGER.exception("Unknown error during config flow")
-                errors["base"] = "unknown"
-            except Exception:  # pylint: disable=broad-except
-                LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
+            errors = await self._async_validate_credentials(
+                email=user_input[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                pool_id=user_input[CONF_POOL_ID],
+            )
+            if not errors:
                 return self.async_create_entry(
                     title=user_input[CONF_EMAIL],
                     data=user_input,
@@ -67,6 +71,101 @@ class IndygoPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reauthentication triggered by an authentication failure."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Confirm reauthentication with a new password."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            errors = await self._async_validate_credentials(
+                email=reauth_entry.data[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                pool_id=reauth_entry.data[CONF_POOL_ID],
+            )
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_PASSWORD: user_input[CONF_PASSWORD]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
+            description_placeholders={CONF_EMAIL: reauth_entry.data[CONF_EMAIL]},
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reconfiguration of email, password or pool ID."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            new_pool_id = user_input[CONF_POOL_ID]
+            if new_pool_id != entry.unique_id and any(
+                other.entry_id != entry.entry_id and other.unique_id == new_pool_id
+                for other in self._async_current_entries()
+            ):
+                errors["base"] = "already_configured"
+            else:
+                errors = await self._async_validate_credentials(
+                    email=user_input[CONF_EMAIL],
+                    password=user_input[CONF_PASSWORD],
+                    pool_id=new_pool_id,
+                )
+                if not errors:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        unique_id=new_pool_id,
+                        title=user_input[CONF_EMAIL],
+                        data=user_input,
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL, default=entry.data[CONF_EMAIL]): str,
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Required(CONF_POOL_ID, default=entry.data[CONF_POOL_ID]): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _async_validate_credentials(
+        self, email: str, password: str, pool_id: str
+    ) -> dict[str, str]:
+        """Validate credentials against the MyIndygo API, returning any errors."""
+        errors: dict[str, str] = {}
+        try:
+            await self._test_credentials(
+                email=email, password=password, pool_id=pool_id
+            )
+        except IndygoPoolApiClientAuthenticationError:
+            LOGGER.exception("Authentication error during config flow")
+            errors["base"] = "auth"
+        except IndygoPoolApiClientCommunicationError:
+            LOGGER.exception("Communication error during config flow")
+            errors["base"] = "connection"
+        except IndygoPoolApiClientError:
+            LOGGER.exception("Unknown error during config flow")
+            errors["base"] = "unknown"
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        return errors
+
     async def _test_credentials(self, email: str, password: str, pool_id: str) -> None:
         """Validate credentials."""
         session = async_create_clientsession(self.hass)
@@ -79,3 +178,46 @@ class IndygoPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         # Test credentials by attempting to get data
         await client.async_get_data()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> IndygoPoolOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return IndygoPoolOptionsFlowHandler()
+
+
+class IndygoPoolOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Indygo Pool options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Manage the polling interval option."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={CONF_SCAN_INTERVAL: int(user_input[CONF_SCAN_INTERVAL])}
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=60,
+                            max=3600,
+                            step=30,
+                            unit_of_measurement="s",
+                            mode=NumberSelectorMode.BOX,
+                        )
+                    ),
+                }
+            ),
+        )

--- a/custom_components/indygo_pool/config_flow.py
+++ b/custom_components/indygo_pool/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.const import UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import (
@@ -188,7 +189,7 @@ class IndygoPoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return IndygoPoolOptionsFlowHandler()
 
 
-class IndygoPoolOptionsFlowHandler(config_entries.OptionsFlow):
+class IndygoPoolOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle Indygo Pool options."""
 
     async def async_step_init(
@@ -214,7 +215,7 @@ class IndygoPoolOptionsFlowHandler(config_entries.OptionsFlow):
                             min=60,
                             max=3600,
                             step=30,
-                            unit_of_measurement="s",
+                            unit_of_measurement=UnitOfTime.SECONDS,
                             mode=NumberSelectorMode.BOX,
                         )
                     ),

--- a/custom_components/indygo_pool/const.py
+++ b/custom_components/indygo_pool/const.py
@@ -15,6 +15,10 @@ VERSION: str = json.loads((Path(__file__).parent / "manifest.json").read_text())
 CONF_EMAIL = "email"
 CONF_PASSWORD = "password"
 CONF_POOL_ID = "pool_id"
+CONF_SCAN_INTERVAL = "scan_interval"
+
+# Default polling interval, in seconds (matches the previous hardcoded value).
+DEFAULT_SCAN_INTERVAL = 300
 
 PROGRAM_TYPE_FILTRATION = 4
 # Spotlight / pool light program. Confirmed on LR-PC hardware: the vendor apps

--- a/custom_components/indygo_pool/coordinator.py
+++ b/custom_components/indygo_pool/coordinator.py
@@ -17,7 +17,7 @@ from .api import (
     IndygoPoolApiClientAuthenticationError,
     IndygoPoolApiClientError,
 )
-from .const import DOMAIN, LOGGER
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 from .models import IndygoPoolData
 
 
@@ -39,7 +39,9 @@ class IndygoPoolDataUpdateCoordinator(DataUpdateCoordinator[IndygoPoolData]):
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=5),
+            update_interval=timedelta(
+                seconds=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+            ),
             config_entry=entry,
         )
 

--- a/custom_components/indygo_pool/strings.json
+++ b/custom_components/indygo_pool/strings.json
@@ -9,15 +9,43 @@
                     "password": "Password",
                     "pool_id": "Pool ID"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Reauthenticate Indygo Pool",
+                "description": "Your MyIndygo password is no longer valid for {email}. Please enter the new password.",
+                "data": {
+                    "password": "Password"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Indygo Pool",
+                "description": "Update your MyIndygo credentials or pool ID.",
+                "data": {
+                    "email": "Email",
+                    "password": "Password",
+                    "pool_id": "Pool ID"
+                }
             }
         },
         "error": {
             "auth": "Invalid credentials",
             "connection": "Communication error",
-            "unknown": "Unknown error"
+            "unknown": "Unknown error",
+            "already_configured": "This pool ID is already configured"
         },
         "abort": {
             "already_configured": "Device is already configured"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Indygo Pool Options",
+                "description": "Configure how often the integration polls the MyIndygo API.",
+                "data": {
+                    "scan_interval": "Polling interval (seconds)"
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/indygo_pool/translations/en.json
+++ b/custom_components/indygo_pool/translations/en.json
@@ -6,17 +6,46 @@
                 "description": "Please enter your MyIndygo credentials.",
                 "data": {
                     "email": "Email",
+                    "password": "Password",
+                    "pool_id": "Pool ID"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Reauthenticate Indygo Pool",
+                "description": "Your MyIndygo password is no longer valid for {email}. Please enter the new password.",
+                "data": {
                     "password": "Password"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Indygo Pool",
+                "description": "Update your MyIndygo credentials or pool ID.",
+                "data": {
+                    "email": "Email",
+                    "password": "Password",
+                    "pool_id": "Pool ID"
                 }
             }
         },
         "error": {
             "auth": "Invalid credentials",
             "connection": "Communication error",
-            "unknown": "Unknown error"
+            "unknown": "Unknown error",
+            "already_configured": "This pool ID is already configured"
         },
         "abort": {
             "already_configured": "Device is already configured"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Indygo Pool Options",
+                "description": "Configure how often the integration polls the MyIndygo API.",
+                "data": {
+                    "scan_interval": "Polling interval (seconds)"
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/indygo_pool/translations/fr.json
+++ b/custom_components/indygo_pool/translations/fr.json
@@ -2,21 +2,50 @@
     "config": {
         "step": {
             "user": {
-                "title": "Indygo Pool Configuration",
-                "description": "Please enter your MyIndygo credentials.",
+                "title": "Configuration Indygo Pool",
+                "description": "Merci de saisir tes identifiants MyIndygo.",
                 "data": {
                     "email": "Email",
-                    "password": "Password"
+                    "password": "Mot de passe",
+                    "pool_id": "ID de la piscine"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Réauthentification Indygo Pool",
+                "description": "Ton mot de passe MyIndygo n'est plus valide pour {email}. Merci de saisir le nouveau mot de passe.",
+                "data": {
+                    "password": "Mot de passe"
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfiguration Indygo Pool",
+                "description": "Modifie tes identifiants MyIndygo ou l'ID de la piscine.",
+                "data": {
+                    "email": "Email",
+                    "password": "Mot de passe",
+                    "pool_id": "ID de la piscine"
                 }
             }
         },
         "error": {
-            "auth": "Invalid credentials",
-            "connection": "Communication error",
-            "unknown": "Unknown error"
+            "auth": "Identifiants invalides",
+            "connection": "Erreur de communication",
+            "unknown": "Erreur inconnue",
+            "already_configured": "Cet ID de piscine est déjà configuré"
         },
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Cet appareil est déjà configuré"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Options Indygo Pool",
+                "description": "Configure la fréquence d'interrogation de l'API MyIndygo.",
+                "data": {
+                    "scan_interval": "Intervalle d'interrogation (secondes)"
+                }
+            }
         }
     },
     "entity": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,8 +18,12 @@ from custom_components.indygo_pool.const import (
     CONF_EMAIL,
     CONF_PASSWORD,
     CONF_POOL_ID,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+
+CUSTOM_SCAN_INTERVAL = 120
 
 original_iterdir = pathlib.Path.iterdir
 
@@ -140,3 +144,244 @@ async def test_form_already_configured(hass: HomeAssistant) -> None:
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.asyncio
+async def test_reauth_success(hass: HomeAssistant) -> None:
+    """Test a successful reauthentication flow updates the stored password."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "custom_components.indygo_pool.config_flow.IndygoPoolApiClient.async_get_data",
+        new_callable=AsyncMock,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_PASSWORD: "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "new_password"
+    assert entry.data[CONF_EMAIL] == "test_email"
+
+
+@pytest.mark.asyncio
+async def test_reauth_wrong_password(hass: HomeAssistant) -> None:
+    """Test reauthentication with an invalid password shows an error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "custom_components.indygo_pool.config_flow.IndygoPoolApiClient.async_get_data",
+        side_effect=IndygoPoolApiClientAuthenticationError("test error"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_PASSWORD: "wrong_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "reauth_confirm"
+    assert result2["errors"] == {"base": "auth"}
+    assert entry.data[CONF_PASSWORD] == "old_password"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_success(hass: HomeAssistant) -> None:
+    """Test a successful reconfiguration updates email, password and pool ID."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with patch(
+        "custom_components.indygo_pool.config_flow.IndygoPoolApiClient.async_get_data",
+        new_callable=AsyncMock,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "new_email",
+                CONF_PASSWORD: "new_password",
+                CONF_POOL_ID: "new_pool",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_EMAIL] == "new_email"
+    assert entry.data[CONF_PASSWORD] == "new_password"
+    assert entry.data[CONF_POOL_ID] == "new_pool"
+    assert entry.unique_id == "new_pool"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_wrong_password(hass: HomeAssistant) -> None:
+    """Test reconfiguration with an invalid password shows an error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    with patch(
+        "custom_components.indygo_pool.config_flow.IndygoPoolApiClient.async_get_data",
+        side_effect=IndygoPoolApiClientAuthenticationError("test error"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_EMAIL: "test_email",
+                CONF_PASSWORD: "wrong_password",
+                CONF_POOL_ID: "test_pool",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "reconfigure"
+    assert result2["errors"] == {"base": "auth"}
+    assert entry.data[CONF_PASSWORD] == "old_password"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_pool_id_conflict(hass: HomeAssistant) -> None:
+    """Test reconfiguring to a pool ID already used by another entry is rejected."""
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="other_email",
+        data={
+            CONF_EMAIL: "other_email",
+            CONF_PASSWORD: "other_password",
+            CONF_POOL_ID: "other_pool",
+        },
+        unique_id="other_pool",
+    )
+    other_entry.add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "old_password",
+            CONF_POOL_ID: "other_pool",
+        },
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "reconfigure"
+    assert result2["errors"] == {"base": "already_configured"}
+    assert entry.data[CONF_POOL_ID] == "test_pool"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_default_value(hass: HomeAssistant) -> None:
+    """Test the options flow shows the default scan interval."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "test_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    schema = result["data_schema"].schema
+    (scan_interval_key,) = [key for key in schema if key == CONF_SCAN_INTERVAL]
+    assert scan_interval_key.default() == DEFAULT_SCAN_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_options_flow_changed_interval(hass: HomeAssistant) -> None:
+    """Test a changed scan interval is stored in the entry options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "test_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SCAN_INTERVAL: CUSTOM_SCAN_INTERVAL},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == CUSTOM_SCAN_INTERVAL

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -385,3 +385,36 @@ async def test_options_flow_changed_interval(hass: HomeAssistant) -> None:
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert entry.options[CONF_SCAN_INTERVAL] == CUSTOM_SCAN_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_options_flow_changed_interval_reloads_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test that saving a changed scan interval schedules a reload of the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_email",
+        data={
+            CONF_EMAIL: "test_email",
+            CONF_PASSWORD: "test_password",
+            CONF_POOL_ID: "test_pool",
+        },
+        unique_id="test_pool",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_schedule_reload"
+    ) as mock_schedule_reload:
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_SCAN_INTERVAL: CUSTOM_SCAN_INTERVAL},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == CUSTOM_SCAN_INTERVAL
+    mock_schedule_reload.assert_called_once_with(entry.entry_id)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,6 +11,7 @@ from custom_components.indygo_pool.api import (
     IndygoPoolApiClientAuthenticationError,
     IndygoPoolApiClientError,
 )
+from custom_components.indygo_pool.const import CONF_SCAN_INTERVAL
 from custom_components.indygo_pool.coordinator import IndygoPoolDataUpdateCoordinator
 
 
@@ -27,6 +28,7 @@ def mock_entry():
     """Mock config entry."""
     entry = MagicMock()
     entry.entry_id = "test_id"
+    entry.options = {}
     return entry
 
 
@@ -36,6 +38,16 @@ def test_coordinator_init(hass, mock_client, mock_entry):
     assert coordinator.client == mock_client
     assert coordinator.name == "indygo_pool"
     expected_interval = 300
+    assert coordinator.update_interval.total_seconds() == expected_interval
+
+
+def test_coordinator_init_custom_scan_interval(hass, mock_client, mock_entry):
+    """Test the coordinator honors a scan interval set via the options flow."""
+    mock_entry.options = {CONF_SCAN_INTERVAL: 120}
+
+    coordinator = IndygoPoolDataUpdateCoordinator(hass, mock_client, mock_entry)
+
+    expected_interval = 120
     assert coordinator.update_interval.total_seconds() == expected_interval
 
 


### PR DESCRIPTION
## Summary

Reauth and reconfigure previously required deleting and recreating the integration by hand (no `async_step_reauth`/`async_step_reconfigure` existed), and the 5-minute poll interval was hardcoded with no way to adjust it. This adds all three as they touch the same file and form one "config flow UX" theme:

- `async_step_reauth` / `async_step_reauth_confirm`: prompts only for the new password when the coordinator raises `ConfigEntryAuthFailed`, validated via the existing `_test_credentials` helper.
- `async_step_reconfigure`: lets the user change email, password or Pool ID from the integration's options menu, pre-filling email/Pool ID (never the password). A changed Pool ID that collides with another entry is rejected with a form error.
- An `OptionsFlow` exposing a configurable polling interval (default: 300s, matching the previous hardcoded `timedelta(minutes=5)`), read by the coordinator via `config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)`.

Refs: none

## ✅ Checks

- [x] Tested against real MyIndygo hardware — not tested against physical hardware (no access), only against `pytest-homeassistant-custom-component` mocks
- [x] No hardcoded user-facing strings (added to `strings.json` instead)
- [x] Documentation updated (`README.md`) if behavior or setup changed

## Additional information

HA API notes (checked against the `homeassistant==2025.12.0`-compatible source under `.venv`, not guessed):
- `_get_reauth_entry()` / `_get_reconfigure_entry()` and `async_update_reload_and_abort()` are the current (non-deprecated) helpers; `async_update_reload_and_abort` accepts `unique_id=` directly, which the reconfigure step uses to update the Pool ID in the same call as the data update.
- `OptionsFlow.async_get_options_flow` is a `@staticmethod` returning a handler instance that takes no `config_entry` argument in `__init__`; `self.config_entry` is a read-only property set by the framework, not something the handler should assign itself.

No breaking changes: existing entries keep working unmodified, and the new options default matches the previous hardcoded interval.
