### PR TITLE
fix(tests): restore real DNS resolution and drop coverage gate for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,4 +51,4 @@ jobs:
           email: ${{ secrets.INDYGO_EMAIL }}
           password: ${{ secrets.INDYGO_PASSWORD }}
           pool_id: ${{ secrets.INDYGO_POOL_ID }}
-        run: uv run pytest -s -m integration tests
+        run: uv run pytest -s -m integration tests --no-cov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ pool_id=your_pool_id
 ```
 Then run the integration tests using:
 ```bash
-uv run pytest -s -m integration tests
+uv run pytest -s -m integration tests --no-cov
 ```
 
 ### Sharing Diagnostics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import socket
+
 import pytest
 
 try:
@@ -11,18 +13,35 @@ except ImportError:
         pass
 
 
+# pytest-homeassistant-custom-component patches socket.getaddrinfo/gethostbyname
+# before every test (unconditionally, with no fixture to opt back in) to block
+# accidental DNS resolution. Capture the pristine functions now, at collection
+# time, before that patch is ever applied, so integration tests can restore real
+# DNS resolution for the real MyIndygo hostname.
+_real_getaddrinfo = socket.getaddrinfo
+_real_gethostbyname = socket.gethostbyname
+
+
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     yield
 
 
 @pytest.fixture(autouse=True)
-def allow_socket_fixture(request):
-    """Enable socket for integration tests."""
+def allow_socket_fixture(request, monkeypatch):
+    """Enable real networking for tests marked `integration`.
+
+    Restoring the real resolver must happen before `socket_allow_hosts`, which
+    itself calls `socket.getaddrinfo` to resolve "myindygo.com" into the
+    allow-list — with the patched resolver still active it raises
+    "DNS resolution disabled in tests" instead of returning an address.
+    """
     if request.node.get_closest_marker("integration"):
+        monkeypatch.setattr(socket, "getaddrinfo", _real_getaddrinfo)
+        monkeypatch.setattr(socket, "gethostbyname", _real_gethostbyname)
         enable_socket()
         socket_allow_hosts(
-            ["127.0.0.1", "localhost", "::1", "62.210.52.36", "myindygo.com"],
+            ["127.0.0.1", "localhost", "::1", "myindygo.com"],
             allow_unix_socket=True,
         )
 


### PR DESCRIPTION
## Summary

`ci/scheduled-integration-tests` (#227) merged an `integration-test.yml` workflow that runs the real-API tests, but the first scheduled/manual run failed on two independent bugs, only visible once real credentials actually exercised the path:

1. `tests/conftest.py`'s `allow_socket_fixture` calls `socket_allow_hosts(["myindygo.com", ...])` to widen `pytest-homeassistant-custom-component`'s network allow-list for integration tests. That call resolves the hostname via `socket.getaddrinfo`, but the same HA test plugin patches `socket.getaddrinfo` before every test (unconditionally, no opt-out fixture) to block DNS resolution of anything but literal IPs/localhost. Resolving `myindygo.com` therefore raised `RuntimeError: DNS resolution disabled in tests` before the test even started.
2. `pyproject.toml`'s `addopts` enforces an 85% coverage gate globally, regardless of the `-m` marker filter. Running only the 2 integration tests exercises ~36% of the codebase, so the run failed on coverage even after fixing (1).

Refs: https://github.com/FunFR/ha-indygo-pool/actions/runs/31875010207/job/94989337382

## ✅ Checks

- [x] Tested against real MyIndygo hardware: ran `uv run pytest -s -m integration tests --no-cov` locally against a real pool (both tests pass, `pool_status`/sensors correctly populated).
- [x] No hardcoded user-facing strings (N/A, test/CI only)
- [ ] Documentation updated (`README.md`), N/A, `CONTRIBUTING.md` updated instead (integration test command) since this doesn't change user-facing behavior

## Additional information

Fix: capture `socket.getaddrinfo`/`gethostbyname` at conftest import time, before the HA plugin ever patches them, and restore the originals for the duration of `integration`-marked tests via `monkeypatch` before calling `socket_allow_hosts`. Also pass `--no-cov` to the integration test invocation in both the new workflow and `CONTRIBUTING.md`, since a 2-test subset was never meant to satisfy the full-suite coverage gate.
