### PR TITLE
fix: expose root-level pH and Redox sensors in sensor-only mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy custom_components/indygo_pool
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: pytest
         name: pytest
         entry: uv run pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This file serves as a guide for AI agents working on the `ha-indygo-pool` projec
 4.  **Verify & Commit**: You **MUST** follow the QA Checklist (testing, linting, formatting) and Tech Stack constraints defined in [CONTRIBUTING.md](CONTRIBUTING.md).
     - **Conventional Commits**: Use `feat:`, `fix:`, `refactor:`, etc., for SemVer. Keep commit messages **concise**.
     - **Breaking Changes**: ONLY flag a commit as a breaking change (`!`) if it fundamentally breaks the user's HA configuration (e.g., removing an entity entirely, changing the integration domain, or altering required config steps).
+    - **`uv run mypy custom_components/indygo_pool` before every push**: CI runs it, but it is *not* in `.pre-commit-config.yaml` (only ruff/pytest are), so it won't be caught locally unless run explicitly.
     - **Mandatory local end-to-end check before any PR**: beyond `pytest tests`, run the real-API integration tests (`uv run pytest -s -m integration tests --no-cov`, needs `.env`) and a `docker compose up -d` smoke test (see [CONTRIBUTING.md](CONTRIBUTING.md#manual-config-testing-docker)). Confirm the coordinator logs `Finished fetching indygo_pool data ... (success: True)` with no `ERROR`/`Traceback`, and that every `indygo_pool` entity via `/api/states` is populated (no `unavailable`/`unknown`) — then `docker compose down`. This is how regressions on real hardware get caught; unit tests with mocked payloads are not sufficient on their own.
 
 ## 🚀 Getting a fix to a reporter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This file serves as a guide for AI agents working on the `ha-indygo-pool` projec
 4.  **Verify & Commit**: You **MUST** follow the QA Checklist (testing, linting, formatting) and Tech Stack constraints defined in [CONTRIBUTING.md](CONTRIBUTING.md).
     - **Conventional Commits**: Use `feat:`, `fix:`, `refactor:`, etc., for SemVer. Keep commit messages **concise**.
     - **Breaking Changes**: ONLY flag a commit as a breaking change (`!`) if it fundamentally breaks the user's HA configuration (e.g., removing an entity entirely, changing the integration domain, or altering required config steps).
+    - **Mandatory local end-to-end check before any PR**: beyond `pytest tests`, run the real-API integration tests (`uv run pytest -s -m integration tests --no-cov`, needs `.env`) and a `docker compose up -d` smoke test (see [CONTRIBUTING.md](CONTRIBUTING.md#manual-config-testing-docker)). Confirm the coordinator logs `Finished fetching indygo_pool data ... (success: True)` with no `ERROR`/`Traceback`, and that every `indygo_pool` entity via `/api/states` is populated (no `unavailable`/`unknown`) — then `docker compose down`. This is how regressions on real hardware get caught; unit tests with mocked payloads are not sufficient on their own.
 
 ## 📚 References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ This file serves as a guide for AI agents working on the `ha-indygo-pool` projec
     - **Breaking Changes**: ONLY flag a commit as a breaking change (`!`) if it fundamentally breaks the user's HA configuration (e.g., removing an entity entirely, changing the integration domain, or altering required config steps).
     - **Mandatory local end-to-end check before any PR**: beyond `pytest tests`, run the real-API integration tests (`uv run pytest -s -m integration tests --no-cov`, needs `.env`) and a `docker compose up -d` smoke test (see [CONTRIBUTING.md](CONTRIBUTING.md#manual-config-testing-docker)). Confirm the coordinator logs `Finished fetching indygo_pool data ... (success: True)` with no `ERROR`/`Traceback`, and that every `indygo_pool` entity via `/api/states` is populated (no `unavailable`/`unknown`) — then `docker compose down`. This is how regressions on real hardware get caught; unit tests with mocked payloads are not sufficient on their own.
 
+## 🚀 Getting a fix to a reporter
+
+After merge, publish the resulting draft release (see [CONTRIBUTING.md](CONTRIBUTING.md#-release-process)) as a **pre-release**, not latest — only promote once the reporter confirms the fix on their hardware.
+
 ## 📚 References
 
 - [`CONTRIBUTING.md`](CONTRIBUTING.md): Technology stack, development environment setup, and mandatory quality assurance commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@ This file serves as a guide for AI agents working on the `ha-indygo-pool` projec
 4.  **Verify & Commit**: You **MUST** follow the QA Checklist (testing, linting, formatting) and Tech Stack constraints defined in [CONTRIBUTING.md](CONTRIBUTING.md).
     - **Conventional Commits**: Use `feat:`, `fix:`, `refactor:`, etc., for SemVer. Keep commit messages **concise**.
     - **Breaking Changes**: ONLY flag a commit as a breaking change (`!`) if it fundamentally breaks the user's HA configuration (e.g., removing an entity entirely, changing the integration domain, or altering required config steps).
-    - **`uv run mypy custom_components/indygo_pool` before every push**: CI runs it, but it is *not* in `.pre-commit-config.yaml` (only ruff/pytest are), so it won't be caught locally unless run explicitly.
     - **Mandatory local end-to-end check before any PR**: beyond `pytest tests`, run the real-API integration tests (`uv run pytest -s -m integration tests --no-cov`, needs `.env`) and a `docker compose up -d` smoke test (see [CONTRIBUTING.md](CONTRIBUTING.md#manual-config-testing-docker)). Confirm the coordinator logs `Finished fetching indygo_pool data ... (success: True)` with no `ERROR`/`Traceback`, and that every `indygo_pool` entity via `/api/states` is populated (no `unavailable`/`unknown`) — then `docker compose down`. This is how regressions on real hardware get caught; unit tests with mocked payloads are not sufficient on their own.
 
 ## 🚀 Getting a fix to a reporter

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -322,7 +322,7 @@ class IndygoParser:
         filt_module: IndygoModuleData | None = None,
     ) -> None:
         """Parse root level sensors."""
-        root_sensors_map = {
+        root_sensors_map: dict[str, dict[str, Any]] = {
             "temperature": {
                 "sensor_key": "temperature",
                 "attributes": {"date": "last_measurement_time"},

--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -324,6 +324,15 @@ class IndygoParser:
         """Parse root level sensors."""
         root_sensors_map = {
             "temperature": {
+                "sensor_key": "temperature",
+                "attributes": {"date": "last_measurement_time"},
+            },
+            "lastPhMeasure": {
+                "sensor_key": "ph",
+                "attributes": {"date": "last_measurement_time"},
+            },
+            "lastRedoxMeasure": {
+                "sensor_key": "redox",
                 "attributes": {"date": "last_measurement_time"},
             },
         }
@@ -332,16 +341,19 @@ class IndygoParser:
 
         for key, config in root_sensors_map.items():
             if key in json_data and json_data[key] is not None:
-                temperature = json_data[key]
+                measure = json_data[key]
+                if not isinstance(measure, dict) or measure.get("value") is None:
+                    continue
+                sensor_key = config["sensor_key"]
                 extra_attributes = {}
                 attr_map = config.get("attributes", {})
                 for source_key, target_key in attr_map.items():
-                    if source_key in temperature:
-                        extra_attributes[target_key] = temperature[source_key]
+                    if source_key in measure:
+                        extra_attributes[target_key] = measure[source_key]
 
-                target_sensors[key] = IndygoSensorData(
-                    key=key,
-                    value=temperature["value"],
+                target_sensors[sensor_key] = IndygoSensorData(
+                    key=sensor_key,
+                    value=measure["value"],
                     extra_attributes=extra_attributes,
                 )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -768,6 +768,37 @@ class TestIndygoParser:
         assert ipx_mod.sensors["ph"].value == TEST_PH_IPX
         assert ipx_mod.sensors["ipx_salt"].value == TEST_SALT_IPX
 
+    def test_parse_data_root_ph_and_redox_sensor_only(self):
+        """Sensor-only hardware (LR-PG2, no lr-pc/ipx) reports pH/Redox at
+        root level via lastPhMeasure/lastRedoxMeasure — see issue #216."""
+        parser = IndygoParser()
+        json_data = {
+            "temperature": {"date": TEST_DATE, "value": TEST_TEMP_VALUE},
+            "lastPhMeasure": {"date": TEST_DATE, "value": TEST_PH_VALUE},
+            "lastRedoxMeasure": {"date": TEST_DATE, "value": TEST_REDOX_VALUE},
+        }
+
+        pool_data = parser.parse_data(json_data, "POOL1", None, None)
+
+        assert pool_data.sensors["ph"].value == TEST_PH_VALUE
+        assert (
+            pool_data.sensors["ph"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+        assert pool_data.sensors["redox"].value == TEST_REDOX_VALUE
+        assert (
+            pool_data.sensors["redox"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+
+    def test_parse_data_root_ph_ignores_missing_value(self):
+        """A lastPhMeasure entry without a value should not create a sensor."""
+        parser = IndygoParser()
+        pool_data = parser.parse_data(
+            {"lastPhMeasure": {"date": TEST_DATE}}, "POOL1", None, None
+        )
+        assert "ph" not in pool_data.sensors
+
 
 class TestGetNested:
     """Tests for the _get_nested helper."""


### PR DESCRIPTION
## Summary

In sensor-only mode (no lr-pc/ipx module, e.g. LR-MB-10 + Pool Guard2 only), the `getPoolStatus` payload carries pH and Redox as root-level `lastPhMeasure`/`lastRedoxMeasure` objects, the same shape as `temperature`. The parser only handled `temperature` at root, so those two measurements were silently dropped and no `ph`/`redox` entity was ever created.

Refs: fixes #216 (follow-up on the v2.5.1 sensor-only degradation)

## ✅ Checks

- [x] Tested against real MyIndygo hardware: lr-mb-10, lr-pc-vs2, ipx (my own account) — full regression pass, no change in entity set, no errors/tracebacks in `docker compose logs`, all `indygo_pool` entities populated via `/api/states`
- [ ] Not tested against the reporter's actual sensor-only hardware (LR-MB-10 + Pool Guard2, no lr-pc/ipx) — I don't have that hardware; new parser tests reproduce the payload shape from the issue instead
- [x] No hardcoded user-facing strings (`ph`/`redox` translation keys already exist, used by the module-input path)
- [ ] Documentation updated (`README.md`) — not applicable, no setup/behavior change

## Additional information

Asked @Tuxinit on the issue to confirm on their actual hardware before promoting past beta.