### PR TITLE
fix: fall back to nested status object for root pH/Redox sensors

### DIFF
--- a/custom_components/indygo_pool/parser.py
+++ b/custom_components/indygo_pool/parser.py
@@ -325,14 +325,17 @@ class IndygoParser:
         root_sensors_map: dict[str, dict[str, Any]] = {
             "temperature": {
                 "sensor_key": "temperature",
+                "nested_key": "lastTemperatureMeasure",
                 "attributes": {"date": "last_measurement_time"},
             },
             "lastPhMeasure": {
                 "sensor_key": "ph",
+                "nested_key": "lastPhMeasure",
                 "attributes": {"date": "last_measurement_time"},
             },
             "lastRedoxMeasure": {
                 "sensor_key": "redox",
+                "nested_key": "lastRedoxMeasure",
                 "attributes": {"date": "last_measurement_time"},
             },
         }
@@ -340,22 +343,25 @@ class IndygoParser:
         target_sensors = filt_module.sensors if filt_module else pool_data.sensors
 
         for key, config in root_sensors_map.items():
-            if key in json_data and json_data[key] is not None:
-                measure = json_data[key]
-                if not isinstance(measure, dict) or measure.get("value") is None:
-                    continue
-                sensor_key = config["sensor_key"]
-                extra_attributes = {}
-                attr_map = config.get("attributes", {})
-                for source_key, target_key in attr_map.items():
-                    if source_key in measure:
-                        extra_attributes[target_key] = measure[source_key]
+            measure = json_data.get(key)
+            if measure is None:
+                measure = _get_nested(json_data, "status", config["nested_key"])
+            if measure is None:
+                continue
+            if not isinstance(measure, dict) or measure.get("value") is None:
+                continue
+            sensor_key = config["sensor_key"]
+            extra_attributes = {}
+            attr_map = config.get("attributes", {})
+            for source_key, target_key in attr_map.items():
+                if source_key in measure:
+                    extra_attributes[target_key] = measure[source_key]
 
-                target_sensors[sensor_key] = IndygoSensorData(
-                    key=sensor_key,
-                    value=measure["value"],
-                    extra_attributes=extra_attributes,
-                )
+            target_sensors[sensor_key] = IndygoSensorData(
+                key=sensor_key,
+                value=measure["value"],
+                extra_attributes=extra_attributes,
+            )
 
     def _parse_sensor_state(
         self,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -791,6 +791,39 @@ class TestIndygoParser:
             == TEST_DATE
         )
 
+    def test_parse_data_root_ph_and_redox_nested_under_status(self):
+        """Some sensor-only payloads nest lastPhMeasure/lastRedoxMeasure inside
+        a "status" object instead of the absolute root — see issue #216."""
+        parser = IndygoParser()
+        json_data = {
+            "status": {
+                "lastTemperatureMeasure": {
+                    "date": TEST_DATE,
+                    "value": TEST_TEMP_VALUE,
+                },
+                "lastPhMeasure": {"date": TEST_DATE, "value": TEST_PH_VALUE},
+                "lastRedoxMeasure": {"date": TEST_DATE, "value": TEST_REDOX_VALUE},
+            },
+        }
+
+        pool_data = parser.parse_data(json_data, "POOL1", None, None)
+
+        assert pool_data.sensors["temperature"].value == TEST_TEMP_VALUE
+        assert (
+            pool_data.sensors["temperature"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+        assert pool_data.sensors["ph"].value == TEST_PH_VALUE
+        assert (
+            pool_data.sensors["ph"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+        assert pool_data.sensors["redox"].value == TEST_REDOX_VALUE
+        assert (
+            pool_data.sensors["redox"].extra_attributes["last_measurement_time"]
+            == TEST_DATE
+        )
+
     def test_parse_data_root_ph_ignores_missing_value(self):
         """A lastPhMeasure entry without a value should not create a sensor."""
         parser = IndygoParser()


### PR DESCRIPTION
## Summary

Some sensor-only hardware (LR-PG2) nests `lastTemperatureMeasure`/`lastPhMeasure`/`lastRedoxMeasure` inside a `status` object in the `getPoolStatus` response instead of exposing them at the absolute root, so the v2.6.0 root-level lookup silently found nothing for pH/Redox (temperature happened to also be present at the root in the reporter's case, but the nested-only path was still broken). Falls back to `status.<nested_key>` via the existing `_get_nested` helper (already used by `_parse_scraped_ipx`), keeping a single nested-lookup convention instead of adding a second ad hoc one.

Refs: #216 (https://github.com/FunFR/ha-indygo-pool/issues/216#issuecomment-5313713430)

## ✅ Checks

- [ ] Tested against real MyIndygo hardware — no LR-MB-10/Pool Guard2 hardware on my side; verified with unit tests reproducing the reported nested payload, plus a full regression pass (unit + real-API integration tests + Docker smoke test) on my own lr-pc/ipx hardware
- [x] No hardcoded user-facing strings
- [ ] Documentation updated — not applicable, no behavior/setup change

## Additional information

Awaiting confirmation from the reporter on their LR-PG2 hardware before promoting the next pre-release to stable.