### PR TITLE
chore: use PR automerge for Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,7 @@
                 "digest",
                 "lockFileMaintenance"
             ],
-            "automerge": true,
-            "automergeType": "branch"
+            "automerge": true
         },
         {
             "matchDepTypes": [


### PR DESCRIPTION
## Summary

The `main` ruleset requires a pull request, and no workflow triggers on pushes to `renovate/**`. Branch automerge could therefore never complete, and Renovate was already falling back to opening a pull request anyway. Relying on the default `pr` mode makes the configuration describe what actually happens, and keeps every update going through the test and CodeQL runs before it lands on `main`.

Refs:

## ✅ Checks

- [ ] Tested against real MyIndygo hardware (list the gateway/device models below, e.g. lr-pc, lr-mb-10, ipx)
- [ ] No hardcoded user-facing strings (added to `strings.json` instead)
- [ ] Documentation updated (`README.md`) if behavior or setup changed

## Additional information

Renovate configuration only, no integration code touched, so the hardware and strings checks do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAhCuRzamXWK2Yz3vnLhCi
